### PR TITLE
fix: Make keys uniques in map

### DIFF
--- a/src/app/milestone/page.tsx
+++ b/src/app/milestone/page.tsx
@@ -82,7 +82,7 @@ const MilestonePage = async () => {
 
                     <Flex gap="2">
                       {issue.labels.map((label) => (
-                        <Label label={label} key={label.id} />
+                        <Label label={label} key={issue.id + label.id}/>
                       ))}
                     </Flex>
                   </Flex>
@@ -97,7 +97,7 @@ const MilestonePage = async () => {
               <Table.Cell>
                 <Flex gap="2" height="100%" align="center" justify="center">
                   {(issue.assignees ?? []).map(({ user: assignee }) => (
-                    <Avatar fallback={assignee.login} src={assignee.avatarUrl} key={assignee.id} size="1" />
+                    <Avatar fallback={assignee.login} src={assignee.avatarUrl} key={issue.id + assignee.id} size="1" />
                   ))}
                 </Flex>
               </Table.Cell>


### PR DESCRIPTION
Fixes this error on http://localhost:3000/milestone:
![image](https://github.com/user-attachments/assets/518ead45-849e-411f-9517-54c437c70327)
Related to duplicated `key` values in a `map` usage (arrays in arrays)
