### PR TITLE
fix: Center heading label in issues-table

### DIFF
--- a/src/app/milestone/page.tsx
+++ b/src/app/milestone/page.tsx
@@ -60,7 +60,7 @@ const MilestonePage = async () => {
         <Table.Header>
           <Table.Row>
             <Table.ColumnHeaderCell className="w-full">Issue</Table.ColumnHeaderCell>
-            <Table.ColumnHeaderCell>Assignee(s)</Table.ColumnHeaderCell>
+            <Table.ColumnHeaderCell align="center">Assignee(s)</Table.ColumnHeaderCell>
           </Table.Row>
         </Table.Header>
 


### PR DESCRIPTION
Just fixes a label alignment. Lmk if it's ok.
Since this colomn has thin content, we could center the label "Assignee(s)"

Before

![image](https://github.com/user-attachments/assets/bb208537-5c22-42dd-a386-2f6e62057332)

After 

![image](https://github.com/user-attachments/assets/b5802b92-2b15-45f2-9e1f-19d8d11c4573)
