### PR TITLE
chore: move all QueryClientWrappers instances to the root layout

### DIFF
--- a/src/app/@details/[login]/page.tsx
+++ b/src/app/@details/[login]/page.tsx
@@ -2,7 +2,6 @@ import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query
 
 import { prefetchContributor } from '@/hooks/use-get-contributor';
 
-import QueryClientWrapper from '@/wrapper/query-client';
 
 import ContributorContent from '@/components/features/contributor/contributor-content';
 
@@ -20,11 +19,9 @@ const ContributorPage = async ({ params }: { params: { login: string } }) => {
   await prefetchContributor(queryClient, formattedLogin);
 
   return (
-    <QueryClientWrapper>
-      <HydrationBoundary state={dehydrate(queryClient)}>
-        <ContributorContent {...{ login: formattedLogin }} />
-      </HydrationBoundary>
-    </QueryClientWrapper>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <ContributorContent {...{ login: formattedLogin }} />
+    </HydrationBoundary>
   );
 };
 

--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -3,7 +3,6 @@ import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query
 import AnalyticsClientPage from '@/components/features/analytics/analytics-client-page';
 import { prefetchContributors } from '@/hooks/use-get-contributors';
 import { TimeFilter } from '@/utils/github';
-import QueryClientWrapper from '@/wrappers/query-client';
 
 const AnalyticsPage = async () => {
   const queryClient = new QueryClient();
@@ -11,11 +10,9 @@ const AnalyticsPage = async () => {
   await prefetchContributors(queryClient, { timeFilter: TimeFilter.ALL_TIME });
 
   return (
-    <QueryClientWrapper>
-      <HydrationBoundary state={dehydrate(queryClient)}>
-        <AnalyticsClientPage />
-      </HydrationBoundary>
-    </QueryClientWrapper>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <AnalyticsClientPage />
+    </HydrationBoundary>
   );
 };
 

--- a/src/app/default.tsx
+++ b/src/app/default.tsx
@@ -4,7 +4,6 @@ import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query
 
 import ScoreboardPage from '@/feature/scoreboard-page';
 
-import QueryClientWrapper from '@/wrapper/query-client';
 
 import { prefetchContributors } from '@/hook/use-get-contributors';
 import { prefetchLastIssues } from '@/hook/use-get-last-issues';
@@ -47,11 +46,9 @@ const HomePage = async ({ searchParams: { f, e, r } }: HomePageParams) => {
   ]);
 
   return (
-    <QueryClientWrapper>
-      <HydrationBoundary state={dehydrate(queryClient)}>
-        <ScoreboardPage {...{ exclude, timeFilter, selectedRepositories }} />
-      </HydrationBoundary>
-    </QueryClientWrapper>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <ScoreboardPage {...{ exclude, timeFilter, selectedRepositories }} />
+    </HydrationBoundary>
   );
 };
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,6 +17,7 @@ import ToastProvider from '@/context/toast-context';
 import { AdenaAddress } from '@/components/modules/adena-address';
 import { GithubLink } from '@/components/modules/github-link';
 import AdenaProvider from '@/contexts/adena-context';
+import QueryClientWrapper from '@/wrappers/query-client';
 
 interface RootLayoutProps {
   children?: ReactNode;
@@ -36,61 +37,63 @@ const RootLayout = ({ children, details }: RootLayoutProps) => {
       </head>
 
       <body>
-        <ThemeProvider defaultTheme="light" attribute="class">
-          <Theme>
-            <ToastProvider>
-              <AdenaProvider>
-                <Toaster />
+        <QueryClientWrapper>
+          <ThemeProvider defaultTheme="light" attribute="class">
+            <Theme>
+              <ToastProvider>
+                <AdenaProvider>
+                  <Toaster />
 
-                <Box
-                  position="fixed"
-                  top="0"
-                  left="0"
-                  width="100%"
-                  p="2"
-                  className="z-50 z-[99]"
-                  style={{ background: 'var(--accent-1)', borderBottom: '1px solid var(--gray-a3)' }}
-                >
-                  <Flex justify="between" align="center">
-                    <Flex align="center" gap="4" px="2">
-                      <Button variant="ghost">
-                        <NextLink href="/">Home</NextLink>
-                      </Button>
-
-                      <Button variant="ghost">
-                        <NextLink href="/milestone">Milestone</NextLink>
-                      </Button>
-
-                      <Button variant="ghost">
-                        <NextLink href="/analytics">
-                          Analytics
-                          <Badge color="red">new</Badge>
-                        </NextLink>
-                      </Button>
-                    </Flex>
-
-                    <Flex gap="2" align="center" justify="end">
-                      <AdenaAddress />
-
-                      <GithubLink>
-                        <Button variant="soft">
-                          <LinkNone2Icon />
-                          Link Github Account
+                  <Box
+                    position="fixed"
+                    top="0"
+                    left="0"
+                    width="100%"
+                    p="2"
+                    className="z-50"
+                    style={{ background: 'var(--accent-1)', borderBottom: '1px solid var(--gray-a3)' }}
+                  >
+                    <Flex justify="between" align="center">
+                      <Flex align="center" gap="4" px="2">
+                        <Button variant="ghost">
+                          <NextLink href="/">Home</NextLink>
                         </Button>
-                      </GithubLink>
 
-                      <ThemeSwitch />
+                        <Button variant="ghost">
+                          <NextLink href="/milestone">Milestone</NextLink>
+                        </Button>
+
+                        <Button variant="ghost">
+                          <NextLink href="/analytics">
+                            Analytics
+                            <Badge color="red">new</Badge>
+                          </NextLink>
+                        </Button>
+                      </Flex>
+
+                      <Flex gap="2" align="center" justify="end">
+                        <AdenaAddress />
+
+                        <GithubLink>
+                          <Button variant="soft">
+                            <LinkNone2Icon />
+                            Link Github Account
+                          </Button>
+                        </GithubLink>
+
+                        <ThemeSwitch />
+                      </Flex>
                     </Flex>
-                  </Flex>
-                </Box>
+                  </Box>
 
-                {children}
+                  {children}
 
-                {details}
-              </AdenaProvider>
-            </ToastProvider>
-          </Theme>
-        </ThemeProvider>
+                  {details}
+                </AdenaProvider>
+              </ToastProvider>
+            </Theme>
+          </ThemeProvider>
+        </QueryClientWrapper>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,6 @@ import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query
 
 import ScoreboardPage from '@/feature/scoreboard-page';
 
-import QueryClientWrapper from '@/wrapper/query-client';
 
 import { prefetchContributors } from '@/hook/use-get-contributors';
 import { prefetchLastIssues } from '@/hook/use-get-last-issues';
@@ -47,11 +46,9 @@ const HomePage = async ({ searchParams: { f, e, r } }: HomePageParams) => {
   ]);
 
   return (
-    <QueryClientWrapper>
-      <HydrationBoundary state={dehydrate(queryClient)}>
-        <ScoreboardPage {...{ exclude, timeFilter, selectedRepositories }} />
-      </HydrationBoundary>
-    </QueryClientWrapper>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <ScoreboardPage {...{ exclude, timeFilter, selectedRepositories }} />
+    </HydrationBoundary>
   );
 };
 


### PR DESCRIPTION
This PR refactors the application to provide a single instance of the QueryClientWrapper at the root layout level. All previous usages of QueryClientWrapper in individual pages have been removed.

Why?
- Centralizes React Query context management.
- Prevents issues with multiple QueryClient instances and enables better caching and hydration.
- Simplifies code in individual pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Adjusted the placement of the QueryClientWrapper to wrap the entire application layout, streamlining data-fetching context management.
  - Simplified individual page components by removing redundant QueryClientWrapper usage.

- **Style**
  - Updated layout styling by removing an unnecessary class from a fixed element for cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->