### PR TITLE
feat: rework contributor handler and sync

### DIFF
--- a/server/handler/contributor.go
+++ b/server/handler/contributor.go
@@ -1,17 +1,12 @@
 package handler
 
 import (
-	"context"
 	"encoding/json"
 	"log"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
-	"github.com/dgraph-io/ristretto"
-	"github.com/shurcooL/githubv4"
-	"golang.org/x/oauth2"
 	"gorm.io/gorm"
 )
 
@@ -56,28 +51,6 @@ type topRepository struct {
 	PrimaryLanguage string `json:"primaryLanguage"`
 }
 
-type cachedUser struct {
-	Data      githubUserResponse
-	Timestamp time.Time
-}
-
-var (
-	userCache   *ristretto.Cache
-	cacheExpiry = 10 * time.Minute
-)
-
-func init() {
-	cache, err := ristretto.NewCache(&ristretto.Config{
-		NumCounters: 1e4, // 10x max items
-		MaxCost:     1e3, // max 1000 items
-		BufferItems: 64,
-	})
-	if err != nil {
-		log.Fatalf("Failed to initialize ristretto cache: %v", err)
-	}
-	userCache = cache
-}
-
 func HandleGetContributor(db *gorm.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var err error
@@ -90,12 +63,25 @@ func HandleGetContributor(db *gorm.DB) http.HandlerFunc {
 			return
 		}
 
-		// Lookup login from DB
+		// Lookup user from DB (all fields)
 		var dbUser struct {
-			Login  string
-			Wallet string
+			ID              string
+			Login           string
+			AvatarUrl       string
+			URL             string
+			Name            string
+			Bio             string
+			Location        string
+			JoinDate        *time.Time
+			WebsiteUrl      string
+			TwitterUsername string
+			TotalStars      int
+			TotalRepos      int
+			Followers       int
+			Following       int
+			Wallet          string
 		}
-		err = db.Table("users").Select("login, wallet").Where("login = ?", login).Scan(&dbUser).Error
+		err = db.Table("users").Select("id, login, avatar_url, url, name, bio, location, join_date, website_url, twitter_username, total_stars, total_repos, followers, following, wallet").Where("login = ?", login).Scan(&dbUser).Error
 		if err != nil {
 			log.Printf("[Contributor Handler] DB error for login %s: %v", login, err)
 			http.Error(w, "Database error", http.StatusInternalServerError)
@@ -107,79 +93,18 @@ func HandleGetContributor(db *gorm.DB) http.HandlerFunc {
 			return
 		}
 
-		// Check cache
-		if val, found := userCache.Get(login); found {
-			if cached, ok := val.(cachedUser); ok && time.Since(cached.Timestamp) < cacheExpiry {
-				log.Printf("[Contributor Handler] Cache hit for user: %s", login)
-				json.NewEncoder(w).Encode(cached.Data)
-				return
-			}
-		}
-		log.Printf("[Contributor Handler] Cache miss for user: %s. Querying GitHub API...", login)
-
-		// Prepare GitHub client
-		src := oauth2.StaticTokenSource(
-			&oauth2.Token{AccessToken: os.Getenv("GITHUB_API_TOKEN")},
-		)
-		httpClient := oauth2.NewClient(context.Background(), src)
-		client := githubv4.NewClient(httpClient)
-
-		var q struct {
-			User struct {
-				ID                  string
-				Login               string
-				AvatarUrl           string
-				URL                 string
-				Name                string
-				Bio                 string
-				Location            string
-				CreatedAt           githubv4.DateTime
-				WebsiteUrl          string
-				TwitterUsername     string
-				StarredRepositories struct {
-					TotalCount int
-				}
-				Followers struct {
-					TotalCount int
-				}
-				Following struct {
-					TotalCount int
-				}
-				Repositories struct {
-					TotalCount int
-					Nodes      []struct {
-						NameWithOwner   string
-						Description     string
-						URL             string
-						StargazerCount  int
-						PrimaryLanguage *struct {
-							Name string
-						}
-					}
-				} `graphql:"repositories(first: 3, privacy: PUBLIC, isFork: false, orderBy: {field: STARGAZERS, direction: DESC})"`
-			} `graphql:"user(login: $login)"`
-		}
-		variables := map[string]interface{}{
-			"login": githubv4.String(login),
-		}
-		err = client.Query(context.Background(), &q, variables)
-		if err != nil {
-			log.Printf("[Contributor Handler] GitHub API error for user %s: %v", login, err)
-			http.Error(w, "GitHub API error: "+err.Error(), http.StatusInternalServerError)
-			return
-		}
-		log.Printf("[Contributor Handler] GitHub API success for user: %s", login)
+		log.Printf("[Contributor Handler] Querying DB for user: %s...", login)
 
 		// Fetch stats from DB
 		var totalCommits, totalPRs, totalIssues int64
-		if err := db.Table("commits").Where("author_id = ?", q.User.ID).Count(&totalCommits).Error; err != nil {
-			log.Printf("[Contributor Handler] DB error counting commits for user %s: %v", q.User.ID, err)
+		if err := db.Table("commits").Where("author_id = ?", dbUser.ID).Count(&totalCommits).Error; err != nil {
+			log.Printf("[Contributor Handler] DB error counting commits for user %s: %v", dbUser.ID, err)
 		}
-		if err := db.Table("pull_requests").Where("author_id = ?", q.User.ID).Count(&totalPRs).Error; err != nil {
-			log.Printf("[Contributor Handler] DB error counting pull requests for user %s: %v", q.User.ID, err)
+		if err := db.Table("pull_requests").Where("author_id = ?", dbUser.ID).Count(&totalPRs).Error; err != nil {
+			log.Printf("[Contributor Handler] DB error counting PRs for user %s: %v", dbUser.ID, err)
 		}
-		if err := db.Table("issues").Where("author_id = ?", q.User.ID).Count(&totalIssues).Error; err != nil {
-			log.Printf("[Contributor Handler] DB error counting issues for user %s: %v", q.User.ID, err)
+		if err := db.Table("issues").Where("author_id = ?", dbUser.ID).Count(&totalIssues).Error; err != nil {
+			log.Printf("[Contributor Handler] DB error counting issues for user %s: %v", dbUser.ID, err)
 		}
 
 		// Fetch recent issues from DB
@@ -189,8 +114,8 @@ func HandleGetContributor(db *gorm.DB) http.HandlerFunc {
 			CreatedAt    time.Time
 			RepositoryID string
 		}
-		if err := db.Table("issues").Select("title, url, created_at, repository_id").Where("author_id = ?", q.User.ID).Order("created_at desc").Limit(3).Scan(&recentIssues).Error; err != nil {
-			log.Printf("[Contributor Handler] DB error fetching issues for user %s: %v", q.User.ID, err)
+		if err := db.Table("issues").Select("title, url, created_at, repository_id").Where("author_id = ?", dbUser.ID).Order("created_at desc").Limit(3).Scan(&recentIssues).Error; err != nil {
+			log.Printf("[Contributor Handler] DB error fetching issues for user %s: %v", dbUser.ID, err)
 		}
 
 		// Fetch recent pull requests from DB
@@ -200,8 +125,8 @@ func HandleGetContributor(db *gorm.DB) http.HandlerFunc {
 			CreatedAt    time.Time
 			RepositoryID string
 		}
-		if err := db.Table("pull_requests").Select("title, url, created_at, repository_id").Where("author_id = ?", q.User.ID).Order("created_at desc").Limit(3).Scan(&recentPRs).Error; err != nil {
-			log.Printf("[Contributor Handler] DB error fetching pull requests for user %s: %v", q.User.ID, err)
+		if err := db.Table("pull_requests").Select("title, url, created_at, repository_id").Where("author_id = ?", dbUser.ID).Order("created_at desc").Limit(3).Scan(&recentPRs).Error; err != nil {
+			log.Printf("[Contributor Handler] DB error fetching pull requests for user %s: %v", dbUser.ID, err)
 		}
 
 		// Fetch repository names for issues and PRs from DB
@@ -223,7 +148,7 @@ func HandleGetContributor(db *gorm.DB) http.HandlerFunc {
 				ids = append(ids, id)
 			}
 			if err := db.Table("repositories").Select("id, name_with_owner").Where("id IN ?", ids).Scan(&repos).Error; err != nil {
-				log.Printf("[Contributor Handler] DB error fetching repositories for user %s: %v", q.User.ID, err)
+				log.Printf("[Contributor Handler] DB error fetching repositories for user %s: %v", dbUser.ID, err)
 			}
 			for _, r := range repos {
 				repoNames[r.ID] = r.NameWithOwner
@@ -231,20 +156,25 @@ func HandleGetContributor(db *gorm.DB) http.HandlerFunc {
 		}
 
 		resp = githubUserResponse{
-			ID:                q.User.ID,
-			Login:             q.User.Login,
-			AvatarUrl:         q.User.AvatarUrl,
-			URL:               q.User.URL,
-			Name:              q.User.Name,
-			Bio:               q.User.Bio,
-			Location:          q.User.Location,
-			JoinDate:          q.User.CreatedAt.String(),
-			WebsiteUrl:        q.User.WebsiteUrl,
-			TwitterUsername:   q.User.TwitterUsername,
-			TotalStars:        q.User.StarredRepositories.TotalCount,
-			TotalRepos:        q.User.Repositories.TotalCount,
-			Followers:         q.User.Followers.TotalCount,
-			Following:         q.User.Following.TotalCount,
+			ID:        dbUser.ID,
+			Login:     dbUser.Login,
+			AvatarUrl: dbUser.AvatarUrl,
+			URL:       dbUser.URL,
+			Name:      dbUser.Name,
+			Bio:       dbUser.Bio,
+			Location:  dbUser.Location,
+			JoinDate: func() string {
+				if dbUser.JoinDate != nil {
+					return dbUser.JoinDate.Format(time.RFC3339)
+				}
+				return ""
+			}(),
+			WebsiteUrl:        dbUser.WebsiteUrl,
+			TwitterUsername:   dbUser.TwitterUsername,
+			TotalStars:        dbUser.TotalStars,
+			TotalRepos:        dbUser.TotalRepos,
+			Followers:         dbUser.Followers,
+			Following:         dbUser.Following,
 			TotalCommits:      int(totalCommits),
 			TotalPullRequests: int(totalPRs),
 			TotalIssues:       int(totalIssues),
@@ -275,29 +205,17 @@ func HandleGetContributor(db *gorm.DB) http.HandlerFunc {
 				return out
 			}(),
 			TopRepositories: func() []topRepository {
-				var out []topRepository
-				for _, n := range q.User.Repositories.Nodes {
-					out = append(out, topRepository{
-						NameWithOwner:  n.NameWithOwner,
-						Description:    n.Description,
-						URL:            n.URL,
-						StargazerCount: n.StargazerCount,
-						PrimaryLanguage: func() string {
-							if n.PrimaryLanguage != nil {
-								return n.PrimaryLanguage.Name
-							}
-							return ""
-						}(),
-					})
-				}
-				return out
+				// Not available from DB yet, return empty array instead of nil
+				return []topRepository{}
 			}(),
 			Wallet:     dbUser.Wallet,
 			GnoBalance: "0",
 		}
 
-		userCache.Set(login, cachedUser{Data: resp, Timestamp: time.Now()}, 1)
-		userCache.Wait()
+		// Guarantee TopRepositories is always an array
+		if resp.TopRepositories == nil {
+			resp.TopRepositories = []topRepository{}
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(resp); err != nil {

--- a/server/handler/contributor.go
+++ b/server/handler/contributor.go
@@ -212,11 +212,6 @@ func HandleGetContributor(db *gorm.DB) http.HandlerFunc {
 			GnoBalance: "0",
 		}
 
-		// Guarantee TopRepositories is always an array
-		if resp.TopRepositories == nil {
-			resp.TopRepositories = []topRepository{}
-		}
-
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(resp); err != nil {
 			log.Printf("[Contributor Handler] Error encoding response for user %s: %v", login, err)

--- a/server/models/user.go
+++ b/server/models/user.go
@@ -1,5 +1,7 @@
 package models
 
+import "time"
+
 type User struct {
 	Login     string `json:"login"`
 	ID        string `gorm:"primarykey" json:"id"`
@@ -7,6 +9,16 @@ type User struct {
 	URL       string `json:"URL"`
 	Name      string `json:"name"`
 	Wallet    string `json:"wallet"`
+
+	Bio             string    `json:"bio"`
+	Location        string    `json:"location"`
+	JoinDate        time.Time `json:"joinDate"`
+	WebsiteUrl      string    `json:"websiteUrl"`
+	TwitterUsername string    `json:"twitterUsername"`
+	TotalStars      int       `json:"totalStars"`
+	TotalRepos      int       `json:"totalRepos"`
+	Followers       int       `json:"followers"`
+	Following       int       `json:"following"`
 
 	Issues       []Issue       `gorm:"foreignKey:AuthorID" json:"issues"`
 	PullRequests []PullRequest `gorm:"foreignKey:AuthorID" json:"pullRequests"`

--- a/server/sync/sync.go
+++ b/server/sync/sync.go
@@ -91,7 +91,14 @@ func (s *Syncer) StartSynchonizing() error {
 				}
 			}
 			s.logger.Info("synchronization Finished...")
-			<-time.Tick(time.Minute * 3)
+
+			// After syncing everything else, update user details.
+			err := s.syncUserDetails()
+			if err != nil {
+				s.logger.Errorf("error while syncing user details %s", err.Error())
+			}
+
+			<-time.Tick(2 * time.Hour)
 		}
 	}()
 
@@ -358,7 +365,6 @@ func (s *Syncer) syncMilestones(repository models.Repository) error {
 	return nil
 }
 func (s *Syncer) syncCommits(repository models.Repository) error {
-
 	var q struct {
 		Repository struct {
 			Ref struct {
@@ -411,6 +417,69 @@ func (s *Syncer) syncCommits(repository models.Repository) error {
 		variables["cursor"] = githubv4.NewString(q.Repository.Ref.Target.Commit.History.PageInfo.EndCursor)
 	}
 
+	return nil
+}
+
+
+// syncUserDetails fetches and updates detailed GitHub data for all users
+func (s *Syncer) syncUserDetails() error {
+	var users []models.User
+	if err := s.db.Find(&users).Error; err != nil {
+		s.logger.Errorf("Failed to fetch users for details sync: %v", err)
+		return err
+	}
+
+	for _, user := range users {
+		var q struct {
+			User struct {
+				ID                  string
+				Login               string
+				AvatarUrl           string
+				URL                 string
+				Name                string
+				Bio                 string
+				Location            string
+				CreatedAt           githubv4.DateTime
+				WebsiteUrl          string
+				TwitterUsername     string
+				StarredRepositories struct {
+					TotalCount int
+				}
+				Followers struct {
+					TotalCount int
+				}
+				Following struct {
+					TotalCount int
+				}
+				Repositories struct {
+					TotalCount int
+				}
+			} `graphql:"user(login: $login)"`
+		}
+		variables := map[string]interface{}{
+			"login": githubv4.String(user.Login),
+		}
+		err := s.client.Query(context.Background(), &q, variables)
+		if err != nil {
+			s.logger.Errorf("Failed to fetch details for user %s: %v", user.Login, err)
+			continue
+		}
+
+		// Update user fields
+		user.Bio = q.User.Bio
+		user.Location = q.User.Location
+		user.JoinDate = q.User.CreatedAt.Time
+		user.WebsiteUrl = q.User.WebsiteUrl
+		user.TwitterUsername = q.User.TwitterUsername
+		user.TotalStars = q.User.StarredRepositories.TotalCount
+		user.TotalRepos = q.User.Repositories.TotalCount
+		user.Followers = q.User.Followers.TotalCount
+		user.Following = q.User.Following.TotalCount
+
+		if err := s.db.Save(&user).Error; err != nil {
+			s.logger.Errorf("Failed to update user %s: %v", user.Login, err)
+		}
+	}
 	return nil
 }
 

--- a/server/sync/sync.go
+++ b/server/sync/sync.go
@@ -87,7 +87,7 @@ func (s *Syncer) StartSynchonizing() error {
 
 				err = s.syncCommits(repository)
 				if err != nil {
-					s.logger.Errorf("error while syncing Milestones %s", err.Error())
+					s.logger.Errorf("error while syncing commits %s", err.Error())
 				}
 			}
 			s.logger.Info("synchronization Finished...")
@@ -419,7 +419,6 @@ func (s *Syncer) syncCommits(repository models.Repository) error {
 
 	return nil
 }
-
 
 // syncUserDetails fetches and updates detailed GitHub data for all users
 func (s *Syncer) syncUserDetails() error {

--- a/src/components/features/contributor/contributor-top-repos.tsx
+++ b/src/components/features/contributor/contributor-top-repos.tsx
@@ -8,36 +8,42 @@ const ContributorTopRepos = ({ contributor }: { contributor: TContributor }) => 
     <Card style={{ height: '100%' }}>
       <Flex direction='column' gap='4' p='4' height='100%' overflowY='auto'>
         <Heading size='3'>Top Repositories</Heading>
-        <Flex direction='column' gap='4'>
-          {contributor.topRepositories.map((repo) => (
-            <Flex key={repo.url} align='start' justify='between'>
-              <Flex direction='column' gap='1'>
-                <Flex align='center' gap='2'>
-                  <Text size='2' weight='medium'>
-                    {repo.nameWithOwner}
-                  </Text>
-                  <Badge variant='outline' size='1'>
-                    {repo.primaryLanguage}
-                  </Badge>
-                </Flex>
-                <Text size='1' color='gray'>
-                  {repo.description}
-                </Text>
-                <Flex align='center' gap='1'>
-                  <Star size={12} />
+        {contributor.topRepositories.length === 0 ? (
+          <Text size='2' color='gray'>
+            Nothing to see here (for now ;))
+          </Text>
+        ) : (
+          <Flex direction='column' gap='4'>
+            {contributor.topRepositories.map((repo) => (
+              <Flex key={repo.url} align='start' justify='between'>
+                <Flex direction='column' gap='1'>
+                  <Flex align='center' gap='2'>
+                    <Text size='2' weight='medium'>
+                      {repo.nameWithOwner}
+                    </Text>
+                    <Badge variant='outline' size='1'>
+                      {repo.primaryLanguage}
+                    </Badge>
+                  </Flex>
                   <Text size='1' color='gray'>
-                    {repo.stargazerCount}
+                    {repo.description}
                   </Text>
+                  <Flex align='center' gap='1'>
+                    <Star size={12} />
+                    <Text size='1' color='gray'>
+                      {repo.stargazerCount}
+                    </Text>
+                  </Flex>
                 </Flex>
+                <Link href={repo.url} target='_blank' rel='noopener noreferrer'>
+                  <IconButton variant='ghost' size='1'>
+                    <ExternalLink size={12} />
+                  </IconButton>
+                </Link>
               </Flex>
-              <Link href={repo.url} target='_blank' rel='noopener noreferrer'>
-                <IconButton variant='ghost' size='1'>
-                  <ExternalLink size={12} />
-                </IconButton>
-              </Link>
-            </Flex>
-          ))}
-        </Flex>
+            ))}
+          </Flex>
+        )}
       </Flex>
     </Card>
   );


### PR DESCRIPTION
- We're now fetching the user details for each user in the sync logic, not in the contributor handler.
- The contributor handler now only serves as an endpoint to fetch what's in the the database.
- It also make the sync logic request happen less often (from 3 minutes to 2 hours)