### PR TITLE
feat: hide github link and adena address for now

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -72,14 +72,16 @@ const RootLayout = ({ children, details }: RootLayoutProps) => {
                       </Flex>
 
                       <Flex gap="2" align="center" justify="end">
-                        <AdenaAddress />
+                        <Flex gap="2" align="center" hidden>
+                          <AdenaAddress />
 
-                        <GithubLink>
-                          <Button variant="soft">
-                            <LinkNone2Icon />
-                            Link Github Account
-                          </Button>
-                        </GithubLink>
+                          <GithubLink>
+                            <Button variant="soft">
+                              <LinkNone2Icon />
+                              Link Github Account
+                            </Button>
+                          </GithubLink>
+                        </Flex>
 
                         <ThemeSwitch />
                       </Flex>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - The address and GitHub link in the header are now hidden from view, while the theme switch remains visible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->