### PR TITLE
feat: add tutorials page with video tutorials

### DIFF
--- a/src/app/@details/[login]/page.tsx
+++ b/src/app/@details/[login]/page.tsx
@@ -2,8 +2,15 @@ import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query
 
 import { prefetchContributor } from '@/hooks/use-get-contributor';
 
-
 import ContributorContent from '@/components/features/contributor/contributor-content';
+
+export async function generateMetadata({ params }: { params: { login: string } }) {
+  const { login } = params;
+
+  return {
+    title: `${login} - Gnolove`,
+  };
+}
 
 const ContributorPage = async ({ params }: { params: { login: string } }) => {
   const { login } = params;

--- a/src/app/@details/[login]/page.tsx
+++ b/src/app/@details/[login]/page.tsx
@@ -1,14 +1,17 @@
+import { Metadata } from 'next';
 import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
 
 import { prefetchContributor } from '@/hooks/use-get-contributor';
 
 import ContributorContent from '@/components/features/contributor/contributor-content';
 
-export async function generateMetadata({ params }: { params: { login: string } }) {
-  const { login } = params;
+export async function generateMetadata({ params }: { params: { login: string } }): Promise<Metadata> {
+  const decodedLogin = decodeURIComponent(params.login);
+  const match = decodedLogin.match(/^([^@]*)@([^@]+)$/);
+  const formattedLogin = match ? match[2] : decodedLogin;
 
   return {
-    title: `${login} - Gnolove`,
+    title: `${formattedLogin} - Gnolove`,
   };
 }
 

--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -1,10 +1,11 @@
+import { Metadata } from 'next';
 import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
 
 import AnalyticsClientPage from '@/components/features/analytics/analytics-client-page';
 import { prefetchContributors } from '@/hooks/use-get-contributors';
 import { TimeFilter } from '@/utils/github';
 
-export const metadata = {
+export const metadata: Metadata = {
   title: 'Analytics',
 };
 

--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -4,6 +4,10 @@ import AnalyticsClientPage from '@/components/features/analytics/analytics-clien
 import { prefetchContributors } from '@/hooks/use-get-contributors';
 import { TimeFilter } from '@/utils/github';
 
+export const metadata = {
+  title: 'Analytics',
+};
+
 const AnalyticsPage = async () => {
   const queryClient = new QueryClient();
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,9 @@
 import { ReactNode } from 'react';
 
 import { ThemeProvider } from 'next-themes';
-import NextLink from 'next/link';
 
 import { LinkNone2Icon } from '@radix-ui/react-icons';
-import { Badge, Box, Button, Flex, Theme } from '@radix-ui/themes';
+import { Box, Button, Flex, Theme } from '@radix-ui/themes';
 
 import '@/style/globals.css';
 
@@ -19,6 +18,7 @@ import { GithubLink } from '@/components/modules/github-link';
 import AdenaProvider from '@/contexts/adena-context';
 import QueryClientWrapper from '@/wrappers/query-client';
 import MobileNavDrawer from '@/components/modules/mobile-nav-drawer';
+import NavHeader from '@/components/modules/nav-header';
 
 import { Analytics } from '@vercel/analytics/next';
 
@@ -59,24 +59,7 @@ const RootLayout = ({ children, details }: RootLayoutProps) => {
                     <Flex justify="between" align="center">
 
                       <MobileNavDrawer />
-
-                      <Flex className='hidden md:flex' align="center" gap="4" px="2">
-                        <Button variant="ghost">
-                          <NextLink href="/">Home</NextLink>
-                        </Button>
-
-                        <Button variant="ghost">
-                          <NextLink href="/milestone">Milestone</NextLink>
-                        </Button>
-
-                        <Button variant="ghost">
-                          <NextLink href="/analytics">
-                            Analytics
-                            <Badge color="red">new</Badge>
-                          </NextLink>
-                        </Button>
-                      </Flex>
-
+                      <NavHeader />
                       <Flex gap="2" align="center" justify="end">
                         <AdenaAddress />
 

--- a/src/app/tutorials/page.tsx
+++ b/src/app/tutorials/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from 'next';
 import Tutorials from '@/components/features/tutorials/tutorials';
 
 export const metadata: Metadata = {
-  title: 'Tutorials',
+  title: 'Tutorials and guides',
 };
 
 const TutorialsPage = () => {

--- a/src/app/tutorials/page.tsx
+++ b/src/app/tutorials/page.tsx
@@ -1,0 +1,11 @@
+import Tutorials from '@/components/features/tutorials/tutorials';
+
+export const metadata = {
+  title: 'Tutorials',
+};
+
+const TutorialsPage = () => {
+  return <Tutorials />;
+};
+
+export default TutorialsPage;

--- a/src/app/tutorials/page.tsx
+++ b/src/app/tutorials/page.tsx
@@ -1,6 +1,7 @@
+import { Metadata } from 'next';
 import Tutorials from '@/components/features/tutorials/tutorials';
 
-export const metadata = {
+export const metadata: Metadata = {
   title: 'Tutorials',
 };
 

--- a/src/components/features/tutorials/constants.ts
+++ b/src/components/features/tutorials/constants.ts
@@ -23,4 +23,4 @@ export const TUTORIAL_VIDEOS = [
     src: 'https://www.youtube.com/embed/-Z3M1XVxWU8?si=CuV98ix_ZnjRccpv',
     title: 'Transaction type (Call, Run, Addpkg and Send) - Gno land Education Tutorial',
   },
-];
+] as const satisfies ReadonlyArray<{ src: string; title: string }>;

--- a/src/components/features/tutorials/constants.ts
+++ b/src/components/features/tutorials/constants.ts
@@ -1,0 +1,26 @@
+export const TUTORIAL_VIDEOS = [
+  {
+    src: 'https://www.youtube.com/embed/8vGpGZqy-Ms?si=ZcVC3nYFVUCnQl_C',
+    title: 'Setup local environment - Gno land Education Tutorial',
+  },
+  {
+    src: 'https://www.youtube.com/embed/nzo6QgxQHgw?si=kItFiUScwRd6HX9O',
+    title: 'Build and test your first dApp - Gno land Education Tutorial',
+  },
+  {
+    src: 'https://www.youtube.com/embed/4twoUyjo4rA?si=XgLAH39KPtxPMk4k',
+    title: 'Coins and GRC20 - Gno land Education Tutorial',
+  },
+  {
+    src: 'https://www.youtube.com/embed/SphPgsjKQyQ?si=u9uIWAtLIRWSWR03',
+    title: 'DAOs and Modular Governance on Gno Smart contracts - Gno land Education Tutorial',
+  },
+  {
+    src: 'https://www.youtube.com/embed/Qh73MqxxKTM?si=CeWCHwiO24oSO62S',
+    title: 'AVL Tree vs Map - Gno land Education Tutorial',
+  },
+  {
+    src: 'https://www.youtube.com/embed/-Z3M1XVxWU8?si=CuV98ix_ZnjRccpv',
+    title: 'Transaction type (Call, Run, Addpkg and Send) - Gno land Education Tutorial',
+  },
+];

--- a/src/components/features/tutorials/tutorials.tsx
+++ b/src/components/features/tutorials/tutorials.tsx
@@ -1,0 +1,52 @@
+import { Container, Flex, Heading, Text, Card, Grid, Badge, Button, Section } from '@radix-ui/themes';
+import YoutubeEmbeddedVideo from '@/element/youtube-embedded-video';
+import { TUTORIAL_VIDEOS } from '@/components/features/tutorials/constants';
+import Link from 'next/link';
+
+const Tutorials = () => {
+  return (
+    <Container size='4' py='6'>
+      <Section>
+        <Flex direction='column' align='center' mb='8'>
+          <Heading size='8' align='center' style={{ color: '#dc2626', fontFamily: 'monospace' }}>
+            GNOLOVE
+          </Heading>
+          <Text size='4' align='center' style={{ color: '#ef4444', fontFamily: 'monospace', marginTop: '8px' }}>
+            TUTORIALS & GUIDES
+          </Text>
+        </Flex>
+
+        <Card mb='6' style={{ backgroundColor: 'white', border: '1px solid #e5e5e5' }}>
+          <Flex align='center' justify='between' p='4' wrap='wrap' gap='4'>
+            <Flex align='center' gap='4'>
+              <Badge size='2' color='green'>
+                📚 Learning Hub
+              </Badge>
+              <Text size='2' style={{ color: '#6b7280' }}>
+                {TUTORIAL_VIDEOS.length} video(s) available
+              </Text>
+            </Flex>
+            <Link href='https://www.youtube.com/playlist?list=PLJZrQikyfMc-kBojXgAojOz4UQPuq4DiY' target='_blank'>
+              <Button size='2' style={{ backgroundColor: '#dc2626', color: 'white' }}>
+                Subscribe to Updates
+              </Button>
+            </Link>
+          </Flex>
+        </Card>
+
+        <Grid columns={{ initial: '1', sm: '2', lg: '3' }} gap='6'>
+          {TUTORIAL_VIDEOS.map(({ src, title }) => (
+            <Card key={src}>
+              <Flex direction='column' gap='2'>
+                <YoutubeEmbeddedVideo className="overflow-hidden rounded-4" src={src} />
+                <Text size='3'>{title}</Text>
+              </Flex>
+            </Card>
+          ))}
+        </Grid>
+      </Section>
+    </Container>
+  );
+};
+
+export default Tutorials;

--- a/src/components/features/tutorials/tutorials.tsx
+++ b/src/components/features/tutorials/tutorials.tsx
@@ -9,11 +9,8 @@ const Tutorials = () => {
       <Section>
         <Flex direction='column' align='center' mb='8'>
           <Heading size='8' align='center' color='red' className='font-mono'>
-            GNOLOVE
-          </Heading>
-          <Text size='4' align='center' color='red' className='font-mono mt-1'>
             TUTORIALS & GUIDES
-          </Text>
+          </Heading>
         </Flex>
 
         <Card mb='6' className='bg-white border border-gray-200'>

--- a/src/components/features/tutorials/tutorials.tsx
+++ b/src/components/features/tutorials/tutorials.tsx
@@ -8,26 +8,26 @@ const Tutorials = () => {
     <Container size='4' py='6'>
       <Section>
         <Flex direction='column' align='center' mb='8'>
-          <Heading size='8' align='center' style={{ color: '#dc2626', fontFamily: 'monospace' }}>
+          <Heading size='8' align='center' color='red' className='font-mono'>
             GNOLOVE
           </Heading>
-          <Text size='4' align='center' style={{ color: '#ef4444', fontFamily: 'monospace', marginTop: '8px' }}>
+          <Text size='4' align='center' color='red' className='font-mono mt-1'>
             TUTORIALS & GUIDES
           </Text>
         </Flex>
 
-        <Card mb='6' style={{ backgroundColor: 'white', border: '1px solid #e5e5e5' }}>
+        <Card mb='6' className='bg-white border border-gray-200'>
           <Flex align='center' justify='between' p='4' wrap='wrap' gap='4'>
             <Flex align='center' gap='4'>
               <Badge size='2' color='green'>
                 📚 Learning Hub
               </Badge>
-              <Text size='2' style={{ color: '#6b7280' }}>
+              <Text size='2' color='gray'>
                 {TUTORIAL_VIDEOS.length} video(s) available
               </Text>
             </Flex>
-            <Link href='https://www.youtube.com/playlist?list=PLJZrQikyfMc-kBojXgAojOz4UQPuq4DiY' target='_blank'>
-              <Button size='2' style={{ backgroundColor: '#dc2626', color: 'white' }}>
+            <Link href='https://www.youtube.com/playlist?list=PLJZrQikyfMc-kBojXgAojOz4UQPuq4DiY' target='_blank' rel='noopener noreferrer'>
+              <Button size='2' color='red' variant='solid'>
                 Subscribe to Updates
               </Button>
             </Link>

--- a/src/components/modules/mobile-nav-drawer.tsx
+++ b/src/components/modules/mobile-nav-drawer.tsx
@@ -54,6 +54,14 @@ const MobileNavDrawer = () => {
                       </Link>
                     </Button>
                   </Drawer.Close>
+
+                  <Drawer.Close asChild>
+                    <Button variant="ghost" size="4" asChild>
+                      <Link href="/tutorials">
+                        Tutorials <Badge color="red">new</Badge>
+                      </Link>
+                    </Button>
+                  </Drawer.Close>
                 </Flex>
 
                 <Footer />

--- a/src/components/modules/mobile-nav-drawer.tsx
+++ b/src/components/modules/mobile-nav-drawer.tsx
@@ -38,11 +38,14 @@ const MobileNavDrawer = () => {
                 <Flex direction="column" align="start" gap="6" mt="8" flexGrow="1">
                   {MENU_ITEMS.map((item) => (
                     <Drawer.Close asChild key={item.href}>
-                      <Button variant="ghost" size="4" asChild>
-                        <Link href={item.href}>{item.label}
-                          {item.new && <Badge color='red'>new</Badge>}
-                        </Link>
-                      </Button>
+                      <Link href={item.href}>
+                        <Button variant="ghost" size="4" asChild>
+                          <span>
+                            {item.label}
+                            {item.new && <Badge color='red'>new</Badge>}
+                          </span>
+                        </Button>
+                      </Link>
                     </Drawer.Close>
                   ))}
                 </Flex>

--- a/src/components/modules/mobile-nav-drawer.tsx
+++ b/src/components/modules/mobile-nav-drawer.tsx
@@ -10,6 +10,7 @@ import { Drawer } from 'vaul';
 import MinecraftHeart from '@/image/minecraft-heart.png';
 
 import Footer from '@/components/modules/footer';
+import { MENU_ITEMS } from '@/constants/menu-items';
 
 const MobileNavDrawer = () => {
   return (
@@ -35,33 +36,15 @@ const MobileNavDrawer = () => {
                 </Flex>
 
                 <Flex direction="column" align="start" gap="6" mt="8" flexGrow="1">
-                  <Drawer.Close asChild>
-                    <Button variant="ghost" size="4" asChild>
-                      <Link href="/">Home</Link>
-                    </Button>
-                  </Drawer.Close>
-
-                  <Drawer.Close asChild>
-                    <Button variant="ghost" size="4" asChild>
-                      <Link href="/milestone">Milestone</Link>
-                    </Button>
-                  </Drawer.Close>
-
-                  <Drawer.Close asChild>
-                    <Button variant="ghost" size="4" asChild>
-                      <Link href="/analytics">
-                        Analytics <Badge color="red">new</Badge>
-                      </Link>
-                    </Button>
-                  </Drawer.Close>
-
-                  <Drawer.Close asChild>
-                    <Button variant="ghost" size="4" asChild>
-                      <Link href="/tutorials">
-                        Tutorials <Badge color="red">new</Badge>
-                      </Link>
-                    </Button>
-                  </Drawer.Close>
+                  {MENU_ITEMS.map((item) => (
+                    <Drawer.Close asChild key={item.href}>
+                      <Button variant="ghost" size="4" asChild>
+                        <Link href={item.href}>{item.label}
+                          {item.new && <Badge color='red'>new</Badge>}
+                        </Link>
+                      </Button>
+                    </Drawer.Close>
+                  ))}
                 </Flex>
 
                 <Footer />

--- a/src/components/modules/nav-header.tsx
+++ b/src/components/modules/nav-header.tsx
@@ -1,32 +1,19 @@
 import { Flex, Button, Badge } from '@radix-ui/themes';
 import NextLink from 'next/link';
+import { MENU_ITEMS } from '@/constants/menu-items';
 
 const NavHeader = () => {
   return (
     <Flex className='hidden md:flex' align='center' gap='4' px='2'>
-      <Button variant='ghost'>
-        <NextLink href='/'>Home</NextLink>
-      </Button>
-
-      <Button variant='ghost'>
-        <NextLink href='/milestone'>Milestone</NextLink>
-      </Button>
-
-      <Button variant='ghost'>
-        <NextLink href='/analytics'>
-          Analytics
-          <Badge color='red'>new</Badge>
-        </NextLink>
-      </Button>
-
-      <Button variant='ghost'>
-        <NextLink href='/tutorials'>
-          Tutorials
-          <Badge color='red'>new</Badge>
-        </NextLink>
-      </Button>
+      {MENU_ITEMS.map((item) => (
+        <Button variant='ghost' key={item.href}>
+          <NextLink href={item.href}>
+            {item.label}
+            {item.new && <Badge color='red'>new</Badge>}
+          </NextLink>
+        </Button>
+      ))}
     </Flex>
-
   );
 };
 

--- a/src/components/modules/nav-header.tsx
+++ b/src/components/modules/nav-header.tsx
@@ -6,12 +6,14 @@ const NavHeader = () => {
   return (
     <Flex className='hidden md:flex' align='center' gap='4' px='2'>
       {MENU_ITEMS.map((item) => (
-        <Button variant='ghost' key={item.href}>
-          <NextLink href={item.href}>
-            {item.label}
-            {item.new && <Badge color='red'>new</Badge>}
-          </NextLink>
-        </Button>
+        <NextLink href={item.href} key={item.href}>
+          <Button variant='ghost' asChild>
+            <span>
+              {item.label}
+              {item.new && <Badge color='red'>new</Badge>}
+            </span>
+          </Button>
+        </NextLink>
       ))}
     </Flex>
   );

--- a/src/components/modules/nav-header.tsx
+++ b/src/components/modules/nav-header.tsx
@@ -1,0 +1,33 @@
+import { Flex, Button, Badge } from '@radix-ui/themes';
+import NextLink from 'next/link';
+
+const NavHeader = () => {
+  return (
+    <Flex className='hidden md:flex' align='center' gap='4' px='2'>
+      <Button variant='ghost'>
+        <NextLink href='/'>Home</NextLink>
+      </Button>
+
+      <Button variant='ghost'>
+        <NextLink href='/milestone'>Milestone</NextLink>
+      </Button>
+
+      <Button variant='ghost'>
+        <NextLink href='/analytics'>
+          Analytics
+          <Badge color='red'>new</Badge>
+        </NextLink>
+      </Button>
+
+      <Button variant='ghost'>
+        <NextLink href='/tutorials'>
+          Tutorials
+          <Badge color='red'>new</Badge>
+        </NextLink>
+      </Button>
+    </Flex>
+
+  );
+};
+
+export default NavHeader;

--- a/src/constants/menu-items.ts
+++ b/src/constants/menu-items.ts
@@ -1,0 +1,22 @@
+export const MENU_ITEMS = [
+  {
+    label: 'Home',
+    href: '/',
+    new: false,
+  },
+  {
+    label: 'Milestone',
+    href: '/milestone',
+    new: false,
+  },
+  {
+    label: 'Analytics',
+    href: '/analytics',
+    new: true,
+  },
+  {
+    label: 'Tutorials',
+    href: '/tutorials',
+    new: true,
+  },
+] as const satisfies ReadonlyArray<{ label: string; href: string; new: boolean }>;


### PR DESCRIPTION
<img width="1792" alt="image" src="https://github.com/user-attachments/assets/ce469bcb-0aa7-4885-8892-1d2c9fb3eda3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a Tutorials page featuring a curated list of educational videos about Gno land.
  - Added a navigation link to the Tutorials page in both desktop and mobile navigation menus, highlighted with a "new" badge.
  - Enhanced navigation by consolidating navigation buttons into a new navigation header component.

- **Improvements**
  - Updated page titles for Analytics, Tutorials, and Contributor Details pages for better clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->