### PR TITLE
fix: show login fallback in contributor row

### DIFF
--- a/src/components/features/contributor/contributor-content.tsx
+++ b/src/components/features/contributor/contributor-content.tsx
@@ -32,7 +32,7 @@ const ContributorContent = ({ login }: { login: string }) => {
         mb='4'
       >
         <Flex direction={{ initial: 'column', md: 'row' }} align={{ initial: 'start', md: 'center' }} gap='2'>
-          <Dialog.Title mb='0'>{contributor.name ?? contributor.login}</Dialog.Title>
+          <Dialog.Title mb='0'>{contributor.name || contributor.login}</Dialog.Title>
           <Flex gap='1' align='center'>
             <Badge color='gray' variant='soft' size='1'>
               gnolove.world/@{contributor.login}

--- a/src/components/modules/contributions-dialog.tsx
+++ b/src/components/modules/contributions-dialog.tsx
@@ -36,7 +36,7 @@ const ContributionsDialog = ({ user, children, ...props }: ContributionsDialogPr
       <Dialog.Trigger>{children}</Dialog.Trigger>
 
       <Dialog.Content maxWidth="550px">
-        <Dialog.Title>{user.name ?? user.login} contributions</Dialog.Title>
+        <Dialog.Title>{user.name || user.login} contributions</Dialog.Title>
         <Dialog.Description size="2" mb="4">
           Get information about all the contribution
         </Dialog.Description>

--- a/src/components/modules/contributor-row.tsx
+++ b/src/components/modules/contributor-row.tsx
@@ -71,7 +71,7 @@ const ContributorRow = ({ contributor, rank, showRank }: ContributorRowProps) =>
 
           <Link href={`/@${contributor.login}`} className="min-w-0 max-w-[160px]">
             <Text truncate className="block overflow-hidden text-ellipsis whitespace-nowrap">
-              {contributor.name ?? contributor.login}
+              {contributor.name || contributor.login}
             </Text>
           </Link>
 

--- a/src/components/modules/user-row.tsx
+++ b/src/components/modules/user-row.tsx
@@ -31,7 +31,7 @@ const UserRow = ({ user }: UserRowProps) => {
             className="-my-1 shrink-0 overflow-hidden rounded-full"
           />
 
-          <Text className="w-full truncate">{user.name ?? user.login}</Text>
+          <Text className="w-full truncate">{user.name || user.login}</Text>
 
           <ExternalLinkIcon className="shrink-0 text-blue-10" />
         </Flex>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the logic for displaying contributor and user names to more reliably show a fallback when the primary name is unavailable or empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->