### PR TITLE
fix: tooltip not render due to rechart internal system

### DIFF
--- a/src/components/elements/rechart-tooltip.tsx
+++ b/src/components/elements/rechart-tooltip.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
+
 import { Card, Box, Flex, Text } from '@radix-ui/themes';
-import { Tooltip, type TooltipProps } from 'recharts';
+import { type TooltipProps } from 'recharts';
 
 // @TODO remove the any typing when recharts allows for better typing. (unknown typing doesn't satisfy ValueType constraints)
 interface RechartTooltipProps extends TooltipProps<any, string | number> {
@@ -18,33 +19,31 @@ const RechartTooltip = (props: RechartTooltipProps) => {
   if (!active || !payload || !payload.length) return null;
 
   return (
-    <Tooltip
-      content={
-        <Card>
-          <Box mb="2">
-            {renderLabel ? renderLabel(label, payload) : (
-              <Text size="2" weight="bold">
-                {label}
-              </Text>
-            )}
-          </Box>
-          <Flex direction="column" gap="2">
-            {renderEntries
-              ? renderEntries(payload, label)
-              : payload.map((entry: any, i: number) => (
-                <Flex key={i} gap="2">
-                  <Text size="1" style={{ color: entry.color }}>
-                    {entry.name}:
-                  </Text>
-                  <Text size="1" weight="bold" style={{ color: entry.color }}>
-                    {entry.value}
-                  </Text>
-                </Flex>
-              ))}
-          </Flex>
-        </Card>
-      }
-    />
+    <Card>
+      <Box mb="2">
+        {renderLabel ? (
+          renderLabel(label, payload)
+        ) : (
+          <Text size="2" weight="bold">
+            {label}
+          </Text>
+        )}
+      </Box>
+      <Flex direction="column" gap="2">
+        {renderEntries
+          ? renderEntries(payload, label)
+          : payload.map((entry: any, i: number) => (
+              <Flex key={i} gap="2">
+                <Text size="1" style={{ color: entry.color }}>
+                  {entry.name}:
+                </Text>
+                <Text size="1" weight="bold" style={{ color: entry.color }}>
+                  {entry.value}
+                </Text>
+              </Flex>
+            ))}
+      </Flex>
+    </Card>
   );
 };
 

--- a/src/components/features/analytics/analytics-contributor-line-chart.tsx
+++ b/src/components/features/analytics/analytics-contributor-line-chart.tsx
@@ -5,7 +5,7 @@ import { ReactElement, useMemo, useState } from 'react';
 import { Avatar, Card, Flex, Heading, Text } from '@radix-ui/themes';
 import { parseISO, compareAsc } from 'date-fns';
 import { ArrowDownToLine } from 'lucide-react';
-import { LineChart, Line, XAxis, YAxis, ResponsiveContainer, Customized, CustomizedProps } from 'recharts';
+import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, Customized, CustomizedProps } from 'recharts';
 
 import { getChunkKeyByTimeFilter, TimeFilter } from '@/utils/github';
 import { TEnhancedUserWithStats } from '@/utils/schemas';
@@ -165,20 +165,24 @@ const AnalyticsContributorLineChart = ({ contributors, timeFilter }: Props) => {
             minTickGap={8}
           />
           <YAxis axisLine={false} tickLine={false} allowDecimals={false} tickFormatter={(v) => v.toFixed(0)} />
-          <RechartTooltip
-            renderEntries={(payload) => {
-              const sortedPayload = (payload as Entry[]).slice().sort((a, b) => b.value - a.value);
-              return sortedPayload.map((entry, index) => (
-                <Flex key={index} gap="1">
-                  <Text size="1" style={{ color: entry.color }}>
-                    {entry.name}:
-                  </Text>
-                  <Text size="1" weight="bold" style={{ color: entry.color }}>
-                    {entry.value}
-                  </Text>
-                </Flex>
-              ));
-            }}
+          <Tooltip
+            content={
+              <RechartTooltip
+                renderEntries={(payload) => {
+                  const sortedPayload = (payload as Entry[]).slice().sort((a, b) => b.value - a.value);
+                  return sortedPayload.map((entry, index) => (
+                    <Flex key={index} gap="1">
+                      <Text size="1" style={{ color: entry.color }}>
+                        {entry.name}:
+                      </Text>
+                      <Text size="1" weight="bold" style={{ color: entry.color }}>
+                        {entry.value}
+                      </Text>
+                    </Flex>
+                  ));
+                }}
+              />
+            }
           />
           {contributorLogins.map((login, i) => (
             <Line

--- a/src/components/features/analytics/analytics-recent-activity.tsx
+++ b/src/components/features/analytics/analytics-recent-activity.tsx
@@ -5,7 +5,7 @@ import { useMemo } from 'react';
 import { ChatBubbleIcon, CommitIcon, MixerVerticalIcon } from '@radix-ui/react-icons';
 import { Card, Flex, Heading, Text } from '@radix-ui/themes';
 import { ArrowDownToLine } from 'lucide-react';
-import { ResponsiveContainer, BarChart, XAxis, YAxis, Bar } from 'recharts';
+import { ResponsiveContainer, BarChart, XAxis, YAxis, Tooltip, Bar } from 'recharts';
 
 import { TimeFilter, getChunkKeyByTimeFilter } from '@/utils/github';
 import { TEnhancedUserWithStats } from '@/utils/schemas';
@@ -121,18 +121,22 @@ const AnalyticsRecentActivity = ({ contributors, timeFilter }: Props) => {
             allowDecimals={false}
             tickFormatter={(value) => Math.abs(value).toFixed(0).toString()}
           />
-          <RechartTooltip
+          <Tooltip
             offset={30}
             cursor={{ strokeDasharray: '3 3' }}
-            renderEntries={renderActivityEntries}
-            renderLabel={(_label: string | number | undefined, payload?: any[]) => {
-              const date = payload?.[0]?.payload?.date;
-              return date ? (
-                <Text size="2" weight="bold">
-                  {date}
-                </Text>
-              ) : null;
-            }}
+            content={
+              <RechartTooltip
+                renderEntries={renderActivityEntries}
+                renderLabel={(_label: string | number | undefined, payload?: any[]) => {
+                  const date = payload?.[0]?.payload?.date;
+                  return date ? (
+                    <Text size="2" weight="bold">
+                      {date}
+                    </Text>
+                  ) : null;
+                }}
+              />
+            }
           />
           <Bar maxBarSize={15} radius={[4, 4, 0, 0]} dataKey="commits" fill={fillColors.commits} />
           <Bar maxBarSize={15} radius={[4, 4, 0, 0]} dataKey="issues" fill={fillColors.issues} />

--- a/src/components/features/analytics/analytics-top-contributor-bar-chart.tsx
+++ b/src/components/features/analytics/analytics-top-contributor-bar-chart.tsx
@@ -9,6 +9,7 @@ import {
   Bar,
   XAxis,
   YAxis,
+  Tooltip as NativeRechartTooltip,
   ResponsiveContainer,
   Legend,
   CustomizedProps,
@@ -157,10 +158,10 @@ const AnalyticsTopContributorBarChart = ({ contributors, selectedRepositories }:
         <BarChart data={topContributors} layout="horizontal" margin={{ top: 10, right: 20, bottom: 20, left: 0 }}>
           <XAxis type="category" dataKey="login" hide />
           <YAxis type="number" padding={{ top: 20, bottom: 20 }} />
-          <RechartTooltip
+          <NativeRechartTooltip
             offset={30}
             cursor={{ strokeDasharray: '3 3' }}
-            renderEntries={renderEntries}
+            content={<RechartTooltip renderEntries={renderEntries} />}
           />
           <Legend />
           <Bar dataKey="commitsPercentageOfScore" stackId="a" fill="#8884d8" name="Commits %" />

--- a/src/components/features/contributor/contributor-analytics.tsx
+++ b/src/components/features/contributor/contributor-analytics.tsx
@@ -3,7 +3,7 @@
 import { TContributor, TContributorRepository, TTimeCount, TTopContributedRepo } from '@/utils/schemas';
 import { Box, Flex, Grid, Card, Text, Heading } from '@radix-ui/themes';
 import RechartTooltip from '@/components/elements/rechart-tooltip';
-import { Bar, BarChart, CartesianGrid, Cell, Legend, Pie, PieChart, ResponsiveContainer, XAxis, YAxis } from 'recharts';
+import { Bar, BarChart, CartesianGrid, Cell, Legend, Pie, PieChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import ContributionsHeatmap from './contributions-heatmap';
 import { useMemo } from 'react';
 import CSVExportButton from '@/components/elements/csv-export-button';
@@ -129,7 +129,7 @@ const ContributorAnalytics = ({ contributor }: { contributor: TContributor }) =>
                         stroke='var(--gray-11)'
                       />
                       <YAxis fontSize={12} stroke='var(--gray-11)' />
-                      <RechartTooltip />
+                      <Tooltip content={<RechartTooltip />} />
                       <Bar dataKey='contributions' fill='var(--accent-9)' radius={[4, 4, 0, 0]} />
                     </BarChart>
                   </ResponsiveContainer>
@@ -164,7 +164,7 @@ const ContributorAnalytics = ({ contributor }: { contributor: TContributor }) =>
                         <Cell key={`cell-${index}`} fill={entry.color} />
                       ))}
                     </Pie>
-                    <RechartTooltip />
+                    <Tooltip content={<RechartTooltip />} />
                     <Legend verticalAlign='bottom' height={36} wrapperStyle={{ fontSize: '12px' }} />
                   </PieChart>
                 </ResponsiveContainer>
@@ -198,7 +198,7 @@ const ContributorAnalytics = ({ contributor }: { contributor: TContributor }) =>
                           <Cell key={`cell-${index}`} fill={entry.color} />
                         ))}
                       </Pie>
-                      <RechartTooltip />
+                      <Tooltip content={<RechartTooltip />} />
                       <Legend verticalAlign='bottom' height={36} wrapperStyle={{ fontSize: '12px' }} />
                     </PieChart>
                   </ResponsiveContainer>
@@ -227,7 +227,7 @@ const ContributorAnalytics = ({ contributor }: { contributor: TContributor }) =>
                     <CartesianGrid strokeDasharray='3 3' stroke='var(--gray-6)' />
                     <XAxis dataKey='period' fontSize={12} stroke='var(--gray-11)' />
                     <YAxis fontSize={12} stroke='var(--gray-11)' />
-                    <RechartTooltip />
+                    <Tooltip content={<RechartTooltip />} />
                     <Bar dataKey='commits' fill='#8884d8' name='Commits' radius={[4, 4, 0, 0]} />
                     <Bar dataKey='prs' fill='#82ca9d' name='PRs' radius={[4, 4, 0, 0]} />
                     <Bar dataKey='issues' fill='#ffc658' name='Issues' radius={[4, 4, 0, 0]} />


### PR DESCRIPTION
It is not possible to directly pass Recharts events and props to RechartTooltip component without using native Recharts’ Tooltip component. This is because Recharts internally manages the events and display logic of tooltips. If you completely replace Recharts’ Tooltip component, you lose that logic.