### PR TITLE
feat: add links to gnolove in discord leaderboard

### DIFF
--- a/server/sync/leaderboard.go
+++ b/server/sync/leaderboard.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"sort"
 	"time"
@@ -122,7 +123,7 @@ func FormatLeaderboardMessage(stats []ContributorStats) string {
 		if displayName == "" {
 			displayName = c.Login
 		}
-		userLink := fmt.Sprintf("[**%s**](https://gnolove.world/@%s)", displayName, c.Login)
+		userLink := fmt.Sprintf("[**%s**](https://gnolove.world/@%s)", displayName, url.QueryEscape(c.Login))
 		message += fmt.Sprintf("%s %s - **%.0f** points\n   💻 %d commits • 🔀 %d PRs • 🐛 %d issues\n\n",
 			position, userLink, c.Score, c.TotalCommits, c.TotalPRs, c.TotalIssues)
 		if i == 9 {

--- a/server/sync/leaderboard.go
+++ b/server/sync/leaderboard.go
@@ -122,13 +122,14 @@ func FormatLeaderboardMessage(stats []ContributorStats) string {
 		if displayName == "" {
 			displayName = c.Login
 		}
-		message += fmt.Sprintf("%s **%s** - **%.0f** points\n   💻 %d commits • 🔀 %d PRs • 🐛 %d issues\n\n",
-			position, displayName, c.Score, c.TotalCommits, c.TotalPRs, c.TotalIssues)
+		userLink := fmt.Sprintf("[**%s**](https://gnolove.world/@%s)", displayName, c.Login)
+		message += fmt.Sprintf("%s %s - **%.0f** points\n   💻 %d commits • 🔀 %d PRs • 🐛 %d issues\n\n",
+			position, userLink, c.Score, c.TotalCommits, c.TotalPRs, c.TotalIssues)
 		if i == 9 {
 			break
 		}
 	}
-	message += "\nKeep up the great work! 🚀"
+	message += "\nKeep up the great work! 🚀\n\nSee the full leaderboard on [gnolove.world](https://gnolove.world/?f=weekly)"
 	return message
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Leaderboard messages on Discord now display contributor names as clickable links to their profiles.
  * Added a direct link to view the full leaderboard on gnolove.world at the end of the message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->