### PR TITLE
chore: remove temporary redirects

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -100,27 +100,6 @@ func main() {
 	router.Use(LoggingMiddleware)
 	router.Use(Compress())
 
-	// --- Temporary Redirects from Old Endpoints to New Endpoints ---
-	router.HandleFunc("/getRepositories", func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, "/repositories", http.StatusTemporaryRedirect)
-	})
-	router.HandleFunc("/getStats", func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, "/stats", http.StatusTemporaryRedirect)
-	})
-	router.HandleFunc("/getIssues", func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, "/issues", http.StatusTemporaryRedirect)
-	})
-	router.HandleFunc("/verifyGithubAccount", func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, "/github/verify", http.StatusTemporaryRedirect)
-	})
-	router.HandleFunc("/getGithubUserAndTokenByCode", func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, "/github/oauth/exchange", http.StatusTemporaryRedirect)
-	})
-	router.Post("/link", func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, "/github/link", http.StatusTemporaryRedirect)
-	})
-
-	// --- New Endpoints ---
 	router.HandleFunc("/repositories", handler.HandleGetRepository(database))
 	router.HandleFunc("/stats", handler.HandleGetUserStats(database, cache))
 	router.HandleFunc("/issues", handler.GetIssues(database))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed temporary HTTP redirect routes for outdated API endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->