### PR TITLE
fix: remove gnomonitoring from discord leaderboard bot

### DIFF
--- a/server/sync/leaderboard.go
+++ b/server/sync/leaderboard.go
@@ -62,7 +62,9 @@ func GetContributorsWithScores(db *gorm.DB, since time.Time) ([]ContributorStats
 		if len(excludedRepos) > 0 {
 			q = q.Where("repository_id NOT IN ?", excludedRepos)
 		}
-		q.Group("author_id").Scan(&commitResults)
+		if err := q.Group("author_id").Scan(&commitResults).Error; err != nil {
+			return nil, err
+		}
 	}
 	for _, r := range commitResults {
 		commitsMap[r.AuthorID] = r.Count
@@ -75,7 +77,9 @@ func GetContributorsWithScores(db *gorm.DB, since time.Time) ([]ContributorStats
 		if len(excludedRepos) > 0 {
 			q = q.Where("repository_id NOT IN ?", excludedRepos)
 		}
-		q.Group("author_id").Scan(&issueResults)
+		if err := q.Group("author_id").Scan(&issueResults).Error; err != nil {
+			return nil, err
+		}
 	}
 	for _, r := range issueResults {
 		issuesMap[r.AuthorID] = r.Count
@@ -88,7 +92,9 @@ func GetContributorsWithScores(db *gorm.DB, since time.Time) ([]ContributorStats
 		if len(excludedRepos) > 0 {
 			q = q.Where("repository_id NOT IN ?", excludedRepos)
 		}
-		q.Group("author_id").Scan(&prResults)
+		if err := q.Group("author_id").Scan(&prResults).Error; err != nil {
+			return nil, err
+		}
 	}
 	for _, r := range prResults {
 		prsMap[r.AuthorID] = r.Count
@@ -101,7 +107,9 @@ func GetContributorsWithScores(db *gorm.DB, since time.Time) ([]ContributorStats
 		if len(excludedRepos) > 0 {
 			q = q.Where("repository_id NOT IN ?", excludedRepos)
 		}
-		q.Group("author_id").Scan(&reviewedResults)
+		if err := q.Group("author_id").Scan(&reviewedResults).Error; err != nil {
+			return nil, err
+		}
 	}
 	for _, r := range reviewedResults {
 		reviewedMap[r.AuthorID] = r.Count


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Leaderboard metrics now exclude contributions from non-representative repositories, preventing inflated counts across commits, issues, pull requests, and reviews. Rankings and scores now more accurately reflect relevant activity while preserving existing sorting and scoring behavior.

- **New Features**
  - Administrators can configure excluded repositories via an environment setting, allowing dynamic control over which repositories are omitted from leaderboard aggregations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->