### PR TITLE
fix: render teams correctly on mobile

### DIFF
--- a/src/components/features/scoreboard/best-performing-teams.tsx
+++ b/src/components/features/scoreboard/best-performing-teams.tsx
@@ -90,6 +90,8 @@ const BestPerformingTeams = () => {
             columnGutter={8}
             key={`${timeFilter}-${selectedRepositories.join(',')}`}
             items={teamScores}
+            itemKey={(item) => item.name}
+            overscanBy={teamScores.length}
             render={({index, data: { name, totalScore, members }}) => (
               <Card className="break-inside-avoid" key={name}>
                 <Flex direction="column" gap="2">
@@ -125,7 +127,7 @@ const BestPerformingTeams = () => {
                                 <Box width="24" height="24" />
                               )}
                               <Link href={isOffline ? '' : `/@${member.login}`}>
-                                <Text truncate className={cn('block overflow-hidden text-ellipsis whitespace-nowrap hover:text-blue-10', isOffline && 'text-gray-8')}>{member.name || member.login}</Text>
+                                <Text truncate className={cn('block overflow-hidden text-ellipsis whitespace-nowrap hover:text-blue-10', { 'text-gray-8': isOffline })}>{member.name || member.login}</Text>
                               </Link>
                             </Flex>
                           </Table.Cell>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved scoreboard scrolling performance and stability with many teams, reducing flicker and preserving item positions during updates.
  - Faster, smoother initial render of team tiles for a more responsive experience.
  - No changes to team or member rankings; results remain the same.

- Style
  - More consistent offline appearance for team lists, ensuring gray text styling is reliably applied when offline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->