### PR TITLE
fix: prevent youtube api quota exceeded from making a blank page

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -155,7 +155,8 @@ export const getYoutubeChannelUploadsPlaylistId = async (searchParams: { channel
 
   // Validate inputs: at least one of channelId or channelUsername is required
   if (!channelId && !channelUsername) {
-    throw new Error('Validation error: either channelId or channelUsername must be provided.');
+    console.error('Validation error: either channelId or channelUsername must be provided.');
+    return '';
   }
 
   const url = new URL('https://www.googleapis.com/youtube/v3/channels');
@@ -172,16 +173,18 @@ export const getYoutubeChannelUploadsPlaylistId = async (searchParams: { channel
   // Check HTTP response
   if (!res.ok) {
     const bodyText = await res.text();
-    throw new Error(
+    console.error(
       `YouTube API error: ${res.status} ${res.statusText}${bodyText ? ` - ${bodyText}` : ''}`
     );
+    return '';
   }
 
   const data = await res.json();
 
   const uploads = data.items[0]?.contentDetails?.relatedPlaylists?.uploads;
   if (!uploads) {
-    throw new Error('Channel found but uploads playlist ID is missing in response.');
+    console.error('Channel found but uploads playlist ID is missing in response.');
+    return '';
   }
 
   return YoutubePlaylistIdSchema.parse(uploads);
@@ -203,7 +206,8 @@ export const getYoutubePlaylistVideos = async (playlistId: string, maxResults: n
   // Check HTTP response early and include body text if available
   if (!res.ok) {
     const bodyText = await res.text();
-    throw new Error(`YouTube API error (playlistItems): ${res.status} ${res.statusText}${bodyText ? ` - ${bodyText}` : ''}`);
+    console.error(`YouTube API error (playlistItems): ${res.status} ${res.statusText}${bodyText ? ` - ${bodyText}` : ''}`);
+    return [];
   }
 
   const data = await res.json();
@@ -211,11 +215,13 @@ export const getYoutubePlaylistVideos = async (playlistId: string, maxResults: n
   // Ensure data and items exist
   if (!data || !Array.isArray(data.items)) {
     const apiErrorMessage = data?.error?.message || data?.message;
-    throw new Error(`Invalid YouTube response: items missing or not an array${apiErrorMessage ? ` - ${apiErrorMessage}` : ''}`);
+    console.error(`Invalid YouTube response: items missing or not an array${apiErrorMessage ? ` - ${apiErrorMessage}` : ''}`);
+    return [];
   }
 
   if (data.items.length === 0) {
-    throw new Error('Playlist not found / Playlist items not found');
+    console.error('Playlist not found / Playlist items not found');
+    return [];
   }
 
   return YoutubeVideoPlaylistSchema.parse(data.items);

--- a/src/components/features/scoreboard/scoreboard-page.tsx
+++ b/src/components/features/scoreboard/scoreboard-page.tsx
@@ -32,8 +32,9 @@ import Scoreboard from '@/features/scoreboard/scoreboard';
 import { useOffline } from '@/contexts/offline-context';
 import { cn } from '@/utils/style';
 import Loader from '@/elements/loader';
+import { TYoutubeVideoPlaylist } from '@/utils/schemas';
 
-const ScoreboardPage = ({ videos }: { videos: any }) => {
+const ScoreboardPage = ({ videos }: { videos: TYoutubeVideoPlaylist }) => {
   const { data: allTimeContributors, isPending: isAllTimePending } = useGetContributors({
     timeFilter: TimeFilter.ALL_TIME,
   });
@@ -98,20 +99,22 @@ const ScoreboardPage = ({ videos }: { videos: any }) => {
 
       <Scoreboard />
 
-      <Text weight="bold" size="6" mt="6">
-        🎥 Latest gnoland videos
-      </Text>
+      {videos && videos.length > 0 && (
+        <>
+          <Text weight="bold" size="6" mt="6">
+            🎥 Latest gnoland videos
+          </Text>
 
-      {videos && (
-        <Grid columns={{ initial: '1', xs: '2', md: '3' }} rows="auto" gap="2">
-          {videos.map((video: { snippet: { resourceId: { videoId: string } } }) => (
-            <YoutubeEmbeddedVideo
-              key={video.snippet.resourceId.videoId}
-              className="overflow-hidden rounded-4"
-              src={`https://www.youtube.com/embed/${video.snippet.resourceId.videoId}`}
-            />
-          ))}
-        </Grid>
+          <Grid columns={{ initial: '1', xs: '2', md: '3' }} rows="auto" gap="2">
+            {videos.map((video: { snippet: { resourceId: { videoId: string } } }) => (
+              <YoutubeEmbeddedVideo
+                key={video.snippet.resourceId.videoId}
+                className="overflow-hidden rounded-4"
+                src={`https://www.youtube.com/embed/${video.snippet.resourceId.videoId}`}
+              />
+            ))}
+          </Grid>
+        </>
       )}
     </LayoutContainer>
   );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Scoreboard page now shows the videos section only when videos are available, removing empty or misleading headings and grids.
  - Improved robustness when fetching YouTube data: errors are handled gracefully, preventing crashes and showing empty results when data is unavailable, leading to a more stable experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->