### PR TITLE
add more logs to diag onchain data

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -98,7 +98,7 @@ func main() {
 		panic(err)
 	}
 	router := chi.NewRouter()
-	router.Use(LoggingMiddleware)
+	//router.Use(LoggingMiddleware)
 	router.Use(Compress())
 
 	// repositories


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled per-request logging while keeping compression active.
  * Added additional info-level logs throughout the sync process, including start/finish markers and steps for users, registrations, packages, and proposals.
  * Logged the GraphQL endpoint used by the syncer for diagnostics.
  * No functional or API changes; behavior and error handling remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->