### PR TITLE
fix infinite loop when there are 0 PRs on repo

### DIFF
--- a/server/sync/sync.go
+++ b/server/sync/sync.go
@@ -201,9 +201,9 @@ func (s *Syncer) syncPRs(repository models.Repository) error {
 				return err
 			}
 
-			hasNextPage = q.Repository.PullRequests.PageInfo.HasNextPage
-			variables["cursor"] = githubv4.NewString(q.Repository.PullRequests.PageInfo.EndCursor)
 		}
+		hasNextPage = q.Repository.PullRequests.PageInfo.HasNextPage
+		variables["cursor"] = githubv4.NewString(q.Repository.PullRequests.PageInfo.EndCursor)
 	}
 
 	return nil


### PR DESCRIPTION
There was an infinite for loop when a repository had 0 pull request. condition
hasNextPage never become false as the 
`hasNextPage = q.Repository.Users.PageInfo.HasNextPage`
instruction was inside the for loop with 0 PR the assing whas never executed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of pull request synchronization by correcting pagination handling, preventing potential stalls when a page has no items.
  - Ensures consistent progression through all pages, reducing missed or repeated items during sync.
- **Chores**
  - Internal logic streamlined for more predictable sync behavior without changing user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->