### PR TITLE
feat: add on-chain data in contributor modal

### DIFF
--- a/src/app/@details/[login]/page.tsx
+++ b/src/app/@details/[login]/page.tsx
@@ -5,6 +5,8 @@ import { prefetchContributor } from '@/hooks/use-get-contributor';
 
 import ContributorContent from '@/components/features/contributor/contributor-content';
 import { prefetchUserPackages } from '@/hooks/use-get-user-packages';
+import { prefetchUserNamespaces } from '@/hooks/use-get-user-namespaces';
+import { prefetchUserProposals } from '@/hooks/use-get-user-proposals';
 
 export async function generateMetadata({ params }: { params: { login: string } }): Promise<Metadata> {
   const decodedLogin = decodeURIComponent(params.login);
@@ -29,7 +31,11 @@ const ContributorPage = async ({ params }: { params: { login: string } }) => {
 
   const contributor = await prefetchContributor(queryClient, formattedLogin);
   if (contributor && contributor.wallet) {
-    await prefetchUserPackages(queryClient, contributor.wallet);
+    await Promise.all([
+      prefetchUserPackages(queryClient, contributor.wallet),
+      prefetchUserNamespaces(queryClient, contributor.wallet),
+      prefetchUserProposals(queryClient, contributor.wallet),
+    ]);
   }
   
   return (

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -141,6 +141,24 @@ export const getNamespacesByUser = async (address: string) => {
   return NamespacesSchema.parse(data);
 };
 
+// On-chain proposals
+export const getProposals = async (address?: string) => {
+  const url = new URL('/onchain/proposals', ENV.NEXT_PUBLIC_API_URL);
+  if (address) url.searchParams.set('address', address);
+
+  const res = await fetch(url.toString(), { cache: 'no-cache' });
+  const data = await res.json();
+
+  // Lazily import to avoid circular import issues
+  const { ProposalsSchema } = await import('@/utils/schemas');
+  return ProposalsSchema.parse(data);
+};
+
+export const getProposalsByUser = async (address: string) => {
+  if (!address) return [];
+  return getProposals(address);
+};
+
 export const getScoreFactors = async () => {
   const url = new URL('/score-factors', ENV.NEXT_PUBLIC_API_URL);
 

--- a/src/components/features/contributor/contributor-content.tsx
+++ b/src/components/features/contributor/contributor-content.tsx
@@ -12,10 +12,14 @@ import ContributorAnalytics from './contributor-analytics';
 import { useOffline } from '@/contexts/offline-context';
 import ContributorOnchain from './contributor-onchain';
 import useGetUserPackages from '@/hooks/use-get-user-packages';
+import useGetUserNamespaces from '@/hooks/use-get-user-namespaces';
+import useGetUserProposals from '@/hooks/use-get-user-proposals';
 
 const ContributorContent = ({ login }: { login: string }) => {
   const { data: contributor } = useGetContributor(login);
   const { data: packages } = useGetUserPackages(contributor?.wallet ?? '');
+  const { data: namespaces } = useGetUserNamespaces(contributor?.wallet ?? '');
+  const { data: proposals } = useGetUserProposals(contributor?.wallet ?? '');
   const [loginCopied, setLoginCopied] = useState(false);
   const { isOffline } = useOffline();
   
@@ -121,11 +125,11 @@ const ContributorContent = ({ login }: { login: string }) => {
 
             <Box minHeight='0' style={{ flex: 1 }}>
               {/* Tabs for different views */}
-              <Tabs.Root defaultValue={packages ? 'onchain' : 'analytics'} style={{ display: 'flex', flexDirection: 'column', gap: '4', height: '100%' }}>
+              <Tabs.Root defaultValue={(packages?.length || namespaces?.length || proposals?.length) ? 'onchain' : 'analytics'} style={{ display: 'flex', flexDirection: 'column', gap: '4', height: '100%' }}>
                 <Tabs.List style={{ minHeight: '40px' }}>
-                  {packages && (
+                  {(packages?.length || namespaces?.length || proposals?.length) ? (
                     <Tabs.Trigger value='onchain'>GNO Chain</Tabs.Trigger>
-                  )}
+                  ) : null}
                   <Tabs.Trigger value='analytics'>Analytics</Tabs.Trigger>
                   <Tabs.Trigger value='activity'>Recent Activity</Tabs.Trigger>
                   <Tabs.Trigger value='repositories'>Top Repositories</Tabs.Trigger>
@@ -133,11 +137,11 @@ const ContributorContent = ({ login }: { login: string }) => {
                 </Tabs.List>
 
                 <Box minHeight={{ md: '0' }}>
-                  {packages && (
+                  {(packages?.length || namespaces?.length || proposals?.length) ? (
                     <Tabs.Content value='onchain' style={{ height: '100%'}}>
-                      <ContributorOnchain packages={packages} />
+                      <ContributorOnchain packages={packages ?? []} namespaces={namespaces ?? []} proposals={proposals ?? []} />
                     </Tabs.Content>
-                  )}
+                  ) : null}
                   <Tabs.Content value='analytics' style={{ height: '100%'}}>
                     <ContributorAnalytics contributor={contributor} />
                   </Tabs.Content>

--- a/src/components/features/contributor/contributor-onchain.tsx
+++ b/src/components/features/contributor/contributor-onchain.tsx
@@ -1,17 +1,20 @@
 'use client';
 
-import { TPackage } from '@/utils/schemas';
-import { Card, Flex, Heading, Text, Grid, Select } from '@radix-ui/themes';
+import { TNamespace, TPackage, TProposal } from '@/utils/schemas';
+import { Card, Flex, Heading, Text, Grid, Select, Tabs, Box, Badge } from '@radix-ui/themes';
 import Link from 'next/link';
 import { useMemo, useState } from 'react';
 
-const ContributorOnchain = ({ packages }: { packages: TPackage[] }) => {
-  // Extract unique namespaces
-  const namespaces = useMemo(
+const ContributorOnchain = ({ packages, namespaces, proposals }: { packages: TPackage[]; namespaces: TNamespace[]; proposals: TProposal[] }) => {
+  // Extract unique namespaces from packages for filtering
+  const namespaceOptions = useMemo(
     () => Array.from(new Set(packages.map((pkg) => pkg.namespace))),
     [packages]
   );
   const [selectedNamespace, setSelectedNamespace] = useState<string>('all');
+  const [nsSort, setNsSort] = useState<'desc' | 'asc'>('desc');
+  const [prSort, setPrSort] = useState<'desc' | 'asc'>('desc');
+  const [proposalQuery, setProposalQuery] = useState<string>('');
 
   // Prepare package data
   const packagesData = useMemo(
@@ -29,50 +32,176 @@ const ContributorOnchain = ({ packages }: { packages: TPackage[] }) => {
     [packages, selectedNamespace]
   );
 
+  const hasAny = (packages.length + namespaces.length + proposals.length) > 0;
+
+  // Sorted helpers
+  const namespacesSorted = useMemo(() => {
+    const arr = [...namespaces];
+    arr.sort((a, b) => (nsSort === 'desc' ? b.blockHeight - a.blockHeight : a.blockHeight - b.blockHeight));
+    return arr;
+  }, [namespaces, nsSort]);
+  const proposalsSorted = useMemo(() => {
+    const arr = [...proposals];
+    arr.sort((a, b) => (prSort === 'desc' ? b.blockHeight - a.blockHeight : a.blockHeight - b.blockHeight));
+    return arr;
+  }, [proposals, prSort]);
+  const proposalsShown = useMemo(() => {
+    const q = proposalQuery.trim().toLowerCase();
+    if (!q) return proposalsSorted;
+    return proposalsSorted.filter((p) => p.path.toLowerCase().includes(q));
+  }, [proposalsSorted, proposalQuery]);
+
   return (
     <Card style={{ height: '100%' }}>
       <Flex direction='column' gap='4' height='100%' overflowY='auto'>
         <Heading size='5'>On-chain Contributions</Heading>
-        {packages.length > 0 ? (
-          <>
-            <Heading size='3'>Packages</Heading>
-            <Text size='2'>{packages.length} packages</Text>
-            <Flex align='center' gap='2' mb='2'>
-              <Text size='2'>Filter by namespace:</Text>
-              <Select.Root
-                value={selectedNamespace}
-                onValueChange={setSelectedNamespace}
-              >
-                <Select.Trigger placeholder='All' />
-                <Select.Content>
-                  <Select.Item value='all'>All</Select.Item>
-                  {namespaces.map((ns) => (
-                    <Select.Item key={ns} value={ns}>
-                      {ns}
-                    </Select.Item>
-                  ))}
-                </Select.Content>
-              </Select.Root>
-            </Flex>
-            <Grid columns={{ initial: '1', lg: '3' }} gap='4'>
-              {packagesData.map((pkg) => (
-                <Link
-                  href={pkg.url}
-                  key={pkg.path}
-                  target='_blank'
-                  rel='noopener noreferrer'
-                >
-                  <Card>
-                    <Flex direction='column' gap='2'>
-                      <Text size='1'>/{pkg.namespace}</Text>
-                      <Heading size='5'>{pkg.name}</Heading>
-                      <Text size='2'>Explore {pkg.name}</Text>
+        {hasAny ? (
+          <Tabs.Root defaultValue='packages' style={{ display: 'flex', flexDirection: 'column', gap: '4', height: '100%' }}>
+            <Tabs.List>
+              <Tabs.Trigger value='packages'>
+                <Flex align='center' gap='2'>
+                  <span>Packages</span>
+                  <Badge variant='soft'>{packages.length}</Badge>
+                </Flex>
+              </Tabs.Trigger>
+              <Tabs.Trigger value='namespaces'>
+                <Flex align='center' gap='2'>
+                  <span>Namespaces</span>
+                  <Badge variant='soft'>{namespaces.length}</Badge>
+                </Flex>
+              </Tabs.Trigger>
+              <Tabs.Trigger value='proposals'>
+                <Flex align='center' gap='2'>
+                  <span>Proposals</span>
+                  <Badge variant='soft'>{proposals.length}</Badge>
+                </Flex>
+              </Tabs.Trigger>
+            </Tabs.List>
+
+            <Box>
+              <Tabs.Content value='packages'>
+                <Text size='2' mb='2'>{packages.length} packages</Text>
+                <Flex align='center' gap='2' mb='2'>
+                  <Text size='2'>Filter by namespace:</Text>
+                  <Select.Root
+                    value={selectedNamespace}
+                    onValueChange={setSelectedNamespace}
+                  >
+                    <Select.Trigger placeholder='All' />
+                    <Select.Content>
+                      <Select.Item value='all'>All</Select.Item>
+                      {namespaceOptions.map((ns) => (
+                        <Select.Item key={ns} value={ns}>
+                          {ns}
+                        </Select.Item>
+                      ))}
+                    </Select.Content>
+                  </Select.Root>
+                </Flex>
+                {packagesData.length ? (
+                  <Grid columns={{ initial: '1', lg: '3' }} gap='4'>
+                    {packagesData.map((pkg) => (
+                      <Link
+                        href={pkg.url}
+                        key={pkg.path}
+                        target='_blank'
+                        rel='noopener noreferrer'
+                      >
+                        <Card>
+                          <Flex direction='column' gap='2'>
+                            <Text size='1'>/{pkg.namespace}</Text>
+                            <Heading size='5'>{pkg.name}</Heading>
+                            <Text size='2'>Explore {pkg.name}</Text>
+                          </Flex>
+                        </Card>
+                      </Link>
+                    ))}
+                  </Grid>
+                ) : (
+                  <Text size='2'>No packages found.</Text>
+                )}
+              </Tabs.Content>
+
+              <Tabs.Content value='namespaces'>
+                <Flex align='center' justify='between' mb='2'>
+                  <Text size='2'>{namespacesSorted.length} namespaces</Text>
+                  <Flex align='center' gap='2'>
+                    <Text size='2' color='gray'>Sort</Text>
+                    <Select.Root value={nsSort} onValueChange={(v) => setNsSort(v as 'desc' | 'asc')}>
+                      <Select.Trigger />
+                      <Select.Content>
+                        <Select.Item value='desc'>Newest</Select.Item>
+                        <Select.Item value='asc'>Oldest</Select.Item>
+                      </Select.Content>
+                    </Select.Root>
+                  </Flex>
+                </Flex>
+                {namespacesSorted.length ? (
+                  <Grid columns={{ initial: '1', lg: '3' }} gap='4'>
+                    {namespacesSorted.map((ns) => (
+                      <Card key={`${ns.namespace}-${ns.hash}`}>
+                        <Flex direction='column' gap='2'>
+                          <Text size='1' color='gray'>Owner</Text>
+                          <Text size='2' style={{ fontFamily: 'monospace' }}>{ns.address}</Text>
+                          <Heading size='5'>/{ns.namespace}</Heading>
+                          <Text size='1' color='gray'>Block #{ns.blockHeight}</Text>
+                        </Flex>
+                      </Card>
+                    ))}
+                  </Grid>
+                ) : (
+                  <Text size='2'>No namespaces found.</Text>
+                )}
+              </Tabs.Content>
+
+              <Tabs.Content value='proposals'>
+                <Flex direction='column' gap='2' mb='2'>
+                  <Flex align='center' justify='between'>
+                    <Text size='2'>{proposalsShown.length} proposals</Text>
+                    <Flex align='center' gap='2'>
+                      <Text size='2' color='gray'>Sort</Text>
+                      <Select.Root value={prSort} onValueChange={(v) => setPrSort(v as 'desc' | 'asc')}>
+                        <Select.Trigger />
+                        <Select.Content>
+                          <Select.Item value='desc'>Newest</Select.Item>
+                          <Select.Item value='asc'>Oldest</Select.Item>
+                        </Select.Content>
+                      </Select.Root>
                     </Flex>
-                  </Card>
-                </Link>
-              ))}
-            </Grid>
-          </>
+                  </Flex>
+                  <Flex align='center' gap='2'>
+                    <Text size='2' color='gray'>Filter</Text>
+                    <input
+                      value={proposalQuery}
+                      onChange={(e) => setProposalQuery(e.target.value)}
+                      placeholder='Filter by path...'
+                      style={{ flex: 1, padding: '8px 10px', border: '1px solid var(--gray-a6)', borderRadius: 6 }}
+                    />
+                  </Flex>
+                </Flex>
+                {proposalsShown.length ? (
+                  <Grid columns={{ initial: '1', lg: '2' }} gap='4'>
+                    {proposalsShown.map((p) => (
+                      <Card key={p.id}>
+                        <Flex direction='column' gap='2'>
+                          <Text size='1' color='gray'>Author</Text>
+                          <Text size='2' style={{ fontFamily: 'monospace' }}>{p.address}</Text>
+                          <Text size='1' color='gray'>Path</Text>
+                          <Text size='2' style={{ wordBreak: 'break-word' }}>{p.path}</Text>
+                          <Text size='1' color='gray'>Files</Text>
+                          <Text size='2'>{p.files.length}</Text>
+                          <Text size='1' color='gray'>Block</Text>
+                          <Text size='2'>#{p.blockHeight}</Text>
+                        </Flex>
+                      </Card>
+                    ))}
+                  </Grid>
+                ) : (
+                  <Text size='2'>No proposals found.</Text>
+                )}
+              </Tabs.Content>
+            </Box>
+          </Tabs.Root>
         ) : (
           <Text size='2'>Nothing to see here (for now :))</Text>
         )}

--- a/src/components/features/contributor/contributor-profile.tsx
+++ b/src/components/features/contributor/contributor-profile.tsx
@@ -97,8 +97,7 @@ const ContributorProfile = ({ contributor }: { contributor: TContributor }) => {
                 </Text>
                 <Flex align='center' gap='2'>
                   <Box
-                    py='4'
-                    px='8'
+                    p='4'
                     overflow='hidden'
                     style={{
                       backgroundColor: 'var(--gray-3)',

--- a/src/hooks/use-get-user-namespaces.ts
+++ b/src/hooks/use-get-user-namespaces.ts
@@ -14,6 +14,7 @@ const useGetUserNamespaces = (address: string) => {
   return useQuery({
     queryFn: () => getNamespacesByUser(address),
     queryKey: [...BASE_QUERY_KEY, address],
+    enabled: !!address && address.length > 0,
   });
 };
 

--- a/src/hooks/use-get-user-proposals.ts
+++ b/src/hooks/use-get-user-proposals.ts
@@ -1,0 +1,21 @@
+import { QueryClient, useQuery } from '@tanstack/react-query';
+
+import { getProposalsByUser } from '@/app/actions';
+
+export const BASE_QUERY_KEY = ['user-proposals'];
+
+export const prefetchUserProposals = async (queryClient: QueryClient, address: string) => {
+  const proposals = await getProposalsByUser(address);
+  queryClient.setQueryData([...BASE_QUERY_KEY, address], proposals);
+  return proposals;
+};
+
+const useGetUserProposals = (address: string) => {
+  return useQuery({
+    queryFn: () => getProposalsByUser(address),
+    queryKey: [...BASE_QUERY_KEY, address],
+    enabled: !!address && address.length > 0,
+  });
+};
+
+export default useGetUserProposals;

--- a/src/utils/schemas.ts
+++ b/src/utils/schemas.ts
@@ -319,6 +319,26 @@ export const NamespacesSchema = z.array(NamespaceSchema);
 export type TNamespace = z.infer<typeof NamespaceSchema>;
 export type TNamespaces = z.infer<typeof NamespacesSchema>;
 
+// On-chain proposals
+export const ProposalFileSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  body: z.string(),
+  proposalID: z.string(),
+});
+export type TProposalFile = z.infer<typeof ProposalFileSchema>;
+
+export const ProposalSchema = z.object({
+  id: z.string(),
+  address: z.string(),
+  path: z.string(),
+  blockHeight: z.number(),
+  files: z.array(ProposalFileSchema).default([]),
+});
+export const ProposalsSchema = z.array(ProposalSchema);
+export type TProposal = z.infer<typeof ProposalSchema>;
+export type TProposals = z.infer<typeof ProposalsSchema>;
+
 export const ScoreFactorsSchema = z.object({
   prFactor: z.number(),
   issueFactor: z.number(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Contributor profiles now include Namespaces and Proposals alongside Packages in a tabbed interface with per-tab counts.
  - Added sorting and filtering for Namespaces and Proposals, plus namespace filtering for Packages.
  - Onchain section visibility and default selection now consider data across Packages, Namespaces, and Proposals.
  - Enables retrieval and display of on-chain proposals for users.
  - Expanded scoring factors to include commit and reviewed PR contributions.

- Style
  - Reduced horizontal padding in the On-Chain Wallet display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->