### PR TITLE
fix: make code block readable in dark mode

### DIFF
--- a/src/components/elements/code-block.tsx
+++ b/src/components/elements/code-block.tsx
@@ -14,7 +14,8 @@ type CodeBlockProps = {
 
 const CodeBlock = ({ value, language = '', height = 360 }: CodeBlockProps) => {
   const [copied, setCopied] = useState(false);
-  const { theme } = useTheme();
+  const { resolvedTheme } = useTheme();
+  const isDark = resolvedTheme === 'dark';
 
   const lines = useMemo(() => value.split(/\r?\n/), [value]);
 
@@ -46,7 +47,7 @@ const CodeBlock = ({ value, language = '', height = 360 }: CodeBlockProps) => {
             ))}
           </Box>
           <Box className='px-3 py-2'>
-            <pre className={cn('m-0 leading-6 whitespace-pre font-mono text-[13px]', {'text-whiteA-12': theme === 'dark', 'text-gray-3': theme === 'light' })}>
+            <pre className={cn('m-0 leading-6 whitespace-pre font-mono text-[13px]', isDark ? 'text-whiteA-12' : 'text-gray-3')}>
               <code>{value}</code>
             </pre>
           </Box>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Code blocks now automatically adapt to your selected light or dark theme for improved readability.

* Style
  * Updated code text colors to ensure consistent contrast in both dark and light modes.

* Documentation
  * No user action required; existing behavior (including copy-to-clipboard) remains unchanged.

* Refactor
  * Visual theming applied without altering the public API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->