### PR TITLE
feat: add endpoints to retrieve users by wallet address

### DIFF
--- a/server/handler/users.go
+++ b/server/handler/users.go
@@ -1,0 +1,99 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"gorm.io/gorm"
+
+	"github.com/samouraiworld/topofgnomes/server/models"
+)
+
+// HandleGetUserByWallet returns a single user by wallet address
+func HandleGetUserByWallet(db *gorm.DB) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		address := chi.URLParam(r, "address")
+		if address == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte("address is required"))
+			return
+		}
+
+		var user models.User
+		if err := db.Where("LOWER(wallet) = ?", strings.ToLower(address)).First(&user).Error; err != nil {
+			if err == gorm.ErrRecordNotFound {
+				w.WriteHeader(http.StatusNotFound)
+				w.Write([]byte("user not found"))
+				return
+			}
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(err.Error()))
+			return
+		}
+
+		json.NewEncoder(w).Encode(user)
+	}
+}
+
+// HandleGetUsersByWallets returns users filtered by one or more wallet addresses.
+// Supports:
+// - GET /users?wallet=<addr>
+// - GET /users?wallets=<addr1>,<addr2>
+// - GET /users?wallets=<addr1>&wallets=<addr2> (repeated query param)
+func HandleGetUsersByWallets(db *gorm.DB) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		// Allow either single wallet or multiple wallets
+		wallet := r.URL.Query().Get("wallet")
+		walletsParam := r.URL.Query()["wallets"]
+
+		wallets := make([]string, 0)
+		if wallet != "" {
+			wallets = append(wallets, wallet)
+		}
+		for _, part := range walletsParam {
+			if part == "" {
+				continue
+			}
+			// Support comma-separated lists inside a single wallets parameter
+			for _, w := range strings.Split(part, ",") {
+				w = strings.TrimSpace(w)
+				if w != "" {
+					wallets = append(wallets, w)
+				}
+			}
+		}
+
+		if len(wallets) == 0 {
+			// If no filter provided, return all users
+			var users []models.User
+			if err := db.Find(&users).Error; err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte(err.Error()))
+				return
+			}
+			json.NewEncoder(w).Encode(users)
+			return
+		}
+
+		// Normalize to lowercase to ensure case-insensitive matching
+		lower := make([]string, 0, len(wallets))
+		for _, waddr := range wallets {
+			lower = append(lower, strings.ToLower(waddr))
+		}
+
+		var users []models.User
+		if err := db.Where("LOWER(wallet) IN ?", lower).Find(&users).Error; err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(err.Error()))
+			return
+		}
+
+		json.NewEncoder(w).Encode(users)
+	}
+}

--- a/server/main.go
+++ b/server/main.go
@@ -110,6 +110,8 @@ func main() {
 	router.HandleFunc("/pull-requests/report", handler.GetPullrequestsReportByDate(prRepo))
 	router.HandleFunc("/score-factors", handler.HandleGetScoreFactors)
 	router.HandleFunc("/milestones/{number}", handler.GetMilestone(database))
+	router.HandleFunc("/users", handler.HandleGetUsersByWallets(database))
+	router.HandleFunc("/users/{address}", handler.HandleGetUserByWallet(database))
 	router.HandleFunc("/contributors/newest", handler.HandleGetNewestContributors(database))
 	router.HandleFunc("/github/verify", handler.HandleVerifyGithubAccount(signer, database))
 	router.HandleFunc("/github/oauth/exchange", handler.HandleGetGithubUserAndTokenByCode(signer, database))


### PR DESCRIPTION
This will help us show user profiles on the govdao page later, using addresses from proposals votes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added GET /users endpoint to fetch users, with optional wallet filters:
    - wallet=<address> for a single address
    - wallets=<addr1>,<addr2> (comma-separated or repeated params)
    - Returns all users if no filter is provided
  - Added GET /users/{address} endpoint to fetch a single user by wallet address
  - Matching is case-insensitive; responses are JSON with appropriate status codes (400 for missing address, 404 if not found, 500 on server errors)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->