### PR TITLE
feat: add endpoints to retrieve users based on their addresses

### DIFF
--- a/server/db/db.go
+++ b/server/db/db.go
@@ -9,7 +9,7 @@ import (
 
 func InitDB() (*gorm.DB, error) {
 	var err error
-	db, err := gorm.Open(sqlite.Open("/db/database.db"), &gorm.Config{
+	db, err := gorm.Open(sqlite.Open("db/database.db"), &gorm.Config{
 		Logger: logger.Default.LogMode(logger.Silent),
 	})
 	if err != nil {

--- a/server/handler/users.go
+++ b/server/handler/users.go
@@ -1,0 +1,61 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/samouraiworld/topofgnomes/server/models"
+	"gorm.io/gorm"
+)
+
+// Get all users. Optionally filtered by addresses (comma-separated)
+func HandleGetUsers(db *gorm.DB) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		var users []models.User
+		// Get users depending on the addresses query parameter
+		wallets := r.URL.Query().Get("addresses")
+		if wallets != "" {
+			addresses := strings.Split(wallets, ",")
+			err := db.Model(&models.User{}).Where("wallet IN ?", addresses).Find(&users).Error
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte(err.Error()))
+				return
+			}
+		} else {
+			err := db.Model(&models.User{}).Find(&users).Error
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				w.Write([]byte(err.Error()))
+				return
+			}
+		}
+		json.NewEncoder(w).Encode(users)
+	}
+}
+
+// Get a user based on their address
+func HandleGetUser(db *gorm.DB) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		address := r.PathValue("address")
+		if address == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte("address is required"))
+			return
+		}
+
+		var user models.User
+		err := db.Model(&models.User{}).Where("wallet = ?", address).First(&user).Error
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(err.Error()))
+			return
+		}
+		json.NewEncoder(w).Encode(user)
+	}
+}

--- a/server/main.go
+++ b/server/main.go
@@ -106,6 +106,8 @@ func main() {
 
 	router.HandleFunc("/repositories", handler.HandleGetRepository(database))
 	router.HandleFunc("/stats", handler.HandleGetUserStats(database, cache))
+	router.HandleFunc("/users", handler.HandleGetUsers(database))
+	router.HandleFunc("/users/{address}", handler.HandleGetUser(database))
 	router.HandleFunc("/issues", handler.GetIssues(database))
 	router.HandleFunc("/pull-requests/report", handler.GetPullrequestsReportByDate(prRepo))
 	router.HandleFunc("/score-factors", handler.HandleGetScoreFactors)


### PR DESCRIPTION
Added the following endpoints:
- /users : retrieves all users in db. Can optionally pass the query param "addresses" with comma-separated wallet addresses to retrieve users of said addresses
- /users/{address}: retrieves one user based on given address param

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added REST API endpoints: GET /users and GET /users/{address}.
  - Supports filtering users by wallet via a comma-separated addresses query parameter.
  - Responses are returned as JSON.

- Chores
  - Updated the database file path to be relative, improving portability across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->