### PR TITLE
chore: use copyable component for address

### DIFF
--- a/src/components/features/contributor/contributor-onchain.tsx
+++ b/src/components/features/contributor/contributor-onchain.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Copyable from '@/elements/copyable';
 import { TNamespace, TPackage, TProposal } from '@/utils/schemas';
 import { Card, Flex, Heading, Text, Grid, Select, Tabs, Box, Badge } from '@radix-ui/themes';
 import Link from 'next/link';
@@ -142,7 +143,7 @@ const ContributorOnchain = ({ packages, namespaces, proposals }: { packages: TPa
                       <Card key={`${ns.namespace}-${ns.hash}`}>
                         <Flex direction='column' gap='2'>
                           <Text size='1' color='gray'>Owner</Text>
-                          <Text size='2' style={{ fontFamily: 'monospace' }}>{ns.address}</Text>
+                          <Copyable>{ns.address}</Copyable>
                           <Heading size='5'>/{ns.namespace}</Heading>
                           <Text size='1' color='gray'>Block #{ns.blockHeight}</Text>
                         </Flex>
@@ -185,7 +186,7 @@ const ContributorOnchain = ({ packages, namespaces, proposals }: { packages: TPa
                       <Card key={p.id}>
                         <Flex direction='column' gap='2'>
                           <Text size='1' color='gray'>Author</Text>
-                          <Text size='2' style={{ fontFamily: 'monospace' }}>{p.address}</Text>
+                          <Copyable>{p.address}</Copyable>
                           <Text size='1' color='gray'>Path</Text>
                           <Text size='2' style={{ wordBreak: 'break-word' }}>{p.path}</Text>
                           <Text size='1' color='gray'>Files</Text>

--- a/src/components/features/contributor/contributor-profile.tsx
+++ b/src/components/features/contributor/contributor-profile.tsx
@@ -1,7 +1,9 @@
 import { Box, Flex, Card, Avatar, Text, Heading, Separator, IconButton } from '@radix-ui/themes';
-import { TContributor } from '@/utils/schemas';
-import { Calendar, Copy, Github, Globe, MapPin, Twitter } from 'lucide-react';
+import { Calendar, Github, Globe, MapPin, Twitter } from 'lucide-react';
+
 import Copyable from '@/elements/copyable';
+
+import { TContributor } from '@/utils/schemas';
 
 const ContributorProfile = ({ contributor }: { contributor: TContributor }) => {
   const websiteUrl = /^https?:\/\//i.test(contributor.websiteUrl ?? '')
@@ -9,12 +11,12 @@ const ContributorProfile = ({ contributor }: { contributor: TContributor }) => {
     : `https://${contributor.websiteUrl}`;
 
   return (
-    <Box height='100%' overflow='auto'>
-      <Flex direction='column' gap='4'>
+    <Box height="100%" overflow="auto">
+      <Flex direction="column" gap="4">
         <Card>
-          <Flex direction='column' align='center' gap='4' p='6'>
+          <Flex direction="column" align="center" gap="4" p="6">
             <Avatar
-              size='8'
+              size="8"
               src={contributor.avatarUrl}
               fallback={contributor.name
                 .split(' ')
@@ -22,29 +24,31 @@ const ContributorProfile = ({ contributor }: { contributor: TContributor }) => {
                 .join('')}
             />
 
-            <Flex direction='column' align='center' gap='2'>
-              <Heading size='5' align='center'>{contributor.name}</Heading>
-              <Text size='2' color='gray'>
+            <Flex direction="column" align="center" gap="2">
+              <Heading size="5" align="center">
+                {contributor.name}
+              </Heading>
+              <Text size="2" color="gray">
                 @{contributor.login}
               </Text>
-              <Text size='2' align='center'>
+              <Text size="2" align="center">
                 {contributor.bio}
               </Text>
             </Flex>
 
             {contributor.location && (
-              <Flex align='center' gap='2'>
+              <Flex align="center" gap="2">
                 <MapPin size={16} />
-                <Text size='2' color='gray'>
+                <Text size="2" color="gray">
                   {contributor.location}
                 </Text>
               </Flex>
             )}
 
             {contributor.joinDate && (
-              <Flex align='center' gap='2'>
+              <Flex align="center" gap="2">
                 <Calendar size={16} />
-                <Text size='2' color='gray'>
+                <Text size="2" color="gray">
                   Joined{' '}
                   {new Date(contributor.joinDate).toLocaleDateString('en-US', {
                     year: 'numeric',
@@ -55,30 +59,22 @@ const ContributorProfile = ({ contributor }: { contributor: TContributor }) => {
               </Flex>
             )}
 
-            <Flex gap='2'>
-              <IconButton variant='outline' size='2' asChild>
-                <a
-                  href={contributor.url}
-                  target='_blank'
-                  rel='noopener noreferrer'
-                >
+            <Flex gap="2">
+              <IconButton variant="outline" size="2" asChild>
+                <a href={contributor.url} target="_blank" rel="noopener noreferrer">
                   <Github size={16} />
                 </a>
               </IconButton>
               {contributor.twitterUsername && (
-                <IconButton variant='outline' size='2' asChild>
-                  <a
-                    href={`https://x.com/${contributor.twitterUsername}`}
-                    target='_blank'
-                    rel='noopener noreferrer'
-                  >
+                <IconButton variant="outline" size="2" asChild>
+                  <a href={`https://x.com/${contributor.twitterUsername}`} target="_blank" rel="noopener noreferrer">
                     <Twitter size={16} />
                   </a>
                 </IconButton>
               )}
               {contributor.websiteUrl && (
-                <IconButton variant='outline' size='2' asChild>
-                  <a href={websiteUrl} target='_blank' rel='noopener noreferrer'>
+                <IconButton variant="outline" size="2" asChild>
+                  <a href={websiteUrl} target="_blank" rel="noopener noreferrer">
                     <Globe size={16} />
                   </a>
                 </IconButton>
@@ -90,26 +86,26 @@ const ContributorProfile = ({ contributor }: { contributor: TContributor }) => {
         {/* On-Chain Profile */}
         {contributor.wallet && (
           <Card>
-            <Flex direction='column' gap='3' p='4'>
-              <Heading size='3'>On-Chain Profile</Heading>
+            <Flex direction="column" gap="3" p="4">
+              <Heading size="3">On-Chain Profile</Heading>
               <Box>
-                <Text size='1' color='gray' mb='1'>
+                <Text size="1" color="gray" mb="1">
                   Wallet Address
                 </Text>
-                <Flex align='center' gap='2'>
-                    <Copyable>{contributor.wallet}</Copyable>
+                <Flex align="center" gap="2">
+                  <Copyable>{contributor.wallet}</Copyable>
                 </Flex>
               </Box>
 
-              <Separator size='4' />
+              <Separator size="4" />
 
               {contributor.gnoBalance && (
-                <Flex direction='column' gap='2'>
-                  <Flex justify='between'>
-                    <Text size='1' color='gray'>
+                <Flex direction="column" gap="2">
+                  <Flex justify="between">
+                    <Text size="1" color="gray">
                       GNO Balance
                     </Text>
-                    <Text size='1' style={{ fontFamily: 'monospace' }}>
+                    <Text size="1" style={{ fontFamily: 'monospace' }}>
                       {contributor.gnoBalance}
                     </Text>
                   </Flex>

--- a/src/components/features/contributor/contributor-profile.tsx
+++ b/src/components/features/contributor/contributor-profile.tsx
@@ -1,6 +1,7 @@
 import { Box, Flex, Card, Avatar, Text, Heading, Separator, IconButton } from '@radix-ui/themes';
 import { TContributor } from '@/utils/schemas';
 import { Calendar, Copy, Github, Globe, MapPin, Twitter } from 'lucide-react';
+import Copyable from '@/elements/copyable';
 
 const ContributorProfile = ({ contributor }: { contributor: TContributor }) => {
   const websiteUrl = /^https?:\/\//i.test(contributor.websiteUrl ?? '')
@@ -96,23 +97,7 @@ const ContributorProfile = ({ contributor }: { contributor: TContributor }) => {
                   Wallet Address
                 </Text>
                 <Flex align='center' gap='2'>
-                  <Box
-                    p='4'
-                    overflow='hidden'
-                    style={{
-                      backgroundColor: 'var(--gray-3)',
-                      borderRadius: '4px',
-                      fontFamily: 'monospace',
-                      fontSize: '12px',
-                      flex: 1,
-                      textOverflow: 'ellipsis',
-                    }}
-                  >
-                    {contributor.wallet}
-                  </Box>
-                  <IconButton variant='ghost' size='1' onClick={() => navigator.clipboard.writeText(contributor.wallet)}>
-                    <Copy size={12} />
-                  </IconButton>
+                    <Copyable>{contributor.wallet}</Copyable>
                 </Flex>
               </Box>
 

--- a/src/components/features/govdao/proposal-detail.tsx
+++ b/src/components/features/govdao/proposal-detail.tsx
@@ -6,11 +6,13 @@ import { aggregateVotes, capitalize, getProposalTitle, getStatusColor, percent }
 import RadixMarkdown from '@/elements/radix-markdown';
 import CodeBlock from '@/elements/code-block';
 import { guessLanguageFromFilename } from '@/utils/govdao';
+import Copyable from '@/elements/copyable';
+import React from 'react';
 
-const DetailRow = ({ label, value }: { label: string; value: string }) => (
+const DetailRow = ({ label, value }: { label: string; value: string | React.ReactNode }) => (
   <Flex justify="between" wrap="wrap" align="center">
     <Text color="gray">{label}</Text>
-    <Text>{value}</Text>
+    {typeof value === 'string' ? <Text>{value}</Text> : value}
   </Flex>
 );
 
@@ -77,7 +79,7 @@ const ProposalDetail = ({ id }: { id: string }) => {
                           <Card key={`${v.proposalID}-${v.address}-${v.hash}`} className="p-2">
                             <Flex align="center" justify="between">
                               <Flex direction="column">
-                                <Text size="2" weight="bold">{v.address}</Text>
+                                <Copyable className="font-bold">{v.address}</Copyable>
                               </Flex>
                               <Badge color={color} variant="soft">{v.vote}</Badge>
                             </Flex>
@@ -121,7 +123,7 @@ const ProposalDetail = ({ id }: { id: string }) => {
         <Card className="col-span-full md:col-span-1">
           <Flex direction="column" gap="3">
             <Heading size="4">Details</Heading>
-            <DetailRow label="Proposer" value={proposal.address} />
+            <DetailRow label="Proposer" value={<Copyable className="pl-5">{proposal.address}</Copyable>} />
             <DetailRow label="Block Height" value={String(proposal.blockHeight)} />
             <DetailRow label="Execution Height" value={proposal.executionHeight ? String(proposal.executionHeight) : '-'} />
             <DetailRow label="Files" value={String(proposal.files?.length ?? 0)} />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Addresses across contributor and proposal views are now copyable with one click.
  - Wallet display in On‑Chain Profile updated to a unified copyable UI.

- Refactor
  - Detail rows now support richer content, enabling enhanced address rendering.

- Style
  - Improved visual alignment and spacing in proposal details.
  - Refreshed address styling (replacing monospace blocks) for a cleaner look.
  - Minor icon and formatting consistency improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->