### PR TITLE
fix: prevent contributor modal from compiling when unused

### DIFF
--- a/src/app/@details/[login]/page.tsx
+++ b/src/app/@details/[login]/page.tsx
@@ -18,8 +18,11 @@ export async function generateMetadata({ params }: { params: { login: string } }
   };
 }
 
-const ContributorPage = async ({ params }: { params: { login: string } }) => {
-  const { login } = params;
+const ContributorPage = async ({ params }: { params: Promise<{ login: string }> }) => {
+  const { login } = await params;
+  if (!login) {
+    return null;
+  }
   const decodedLogin = decodeURIComponent(login);
   const match = decodedLogin.match(/^([^@]*)@([^@]+)$/);
   if (!match) {


### PR DESCRIPTION
Right now, the contributor modal (page) under route `/[login]` is sometimes intercepting requests to other routes (e.g. : `/govdao`). This PRs tries to fix this behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability on contributor detail pages by handling delayed or missing login data more gracefully.
  * Prevented occasional rendering errors when opening contributor profiles, reducing chance of crashes or broken views.
  * Ensured smoother navigation to contributor details when data is not immediately available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->