### PR TITLE
feat: add visual indicator for old prs

### DIFF
--- a/src/components/features/report/repo-pr-status-list.tsx
+++ b/src/components/features/report/repo-pr-status-list.tsx
@@ -68,114 +68,121 @@ const RepoPRStatusList = ({ repo, statusMap, isOffline }: RepoPRStatusListProps)
                     const bLogin = b.authorLogin || '';
                     return aLogin.localeCompare(bLogin);
                   })
-                  .map((pr: TPullRequest) => (
-                    <li key={pr.id} className="hover:bg-gray-2">
-                      <Flex
-                        gap="2"
-                        align={{ initial: 'start', sm: 'center' }}
-                        py={{ initial: '2', sm: '1' }}
-                        className="overflow-hidden"
-                        direction={{ initial: 'column', sm: 'row' }}
-                      >
-                        <Flex gap="2">
-                          <Avatar
-                            size="1"
-                            radius="full"
-                            src={pr.authorAvatarUrl}
-                            fallback={pr.authorLogin ? pr.authorLogin[0] : '?'}
-                          />
-                          <Link className="flex items-center" href={isOffline ? '' : `/@${pr.authorLogin}`}>
-                            <Tooltip content={pr.authorLogin}>
+                  .map((pr: TPullRequest) => {
+                    const updatedWeeksAgo = pr.updatedAt ? weeksAgo(pr.updatedAt) : null;
+                    const createdWeeksAgo = pr.createdAt ? weeksAgo(pr.createdAt) : null;
+                    
+                    return (
+                      <li key={pr.id} className="hover:bg-gray-2">
+                        <Flex
+                          gap="2"
+                          align={{ initial: 'start', sm: 'center' }}
+                          py={{ initial: '2', sm: '1' }}
+                          className="overflow-hidden"
+                          direction={{ initial: 'column', sm: 'row' }}
+                        >
+                          <Flex gap="2">
+                            <Avatar
+                              size="1"
+                              radius="full"
+                              src={pr.authorAvatarUrl}
+                              fallback={pr.authorLogin ? pr.authorLogin[0] : '?'}
+                            />
+                            <Link className="flex items-center" href={isOffline ? '' : `/@${pr.authorLogin}`}>
+                              <Tooltip content={pr.authorLogin}>
+                                <Text
+                                  weight="bold"
+                                  size="2"
+                                >
+                                  {pr.authorLogin}
+                                </Text>
+                              </Tooltip>
+                            </Link>
+                          </Flex>
+                          <Link className="flex items-center" href={isOffline ? '' : pr.url} target="_blank" rel="noopener noreferrer">
+                            <Tooltip content={pr.title}>
                               <Text
-                                weight="bold"
                                 size="2"
                               >
-                                {pr.authorLogin}
+                                {pr.title}
                               </Text>
                             </Tooltip>
                           </Link>
-                        </Flex>
-                        <Link className="flex items-center" href={isOffline ? '' : pr.url} target="_blank" rel="noopener noreferrer">
-                          <Tooltip content={pr.title}>
-                            <Text
-                              size="2"
-                            >
-                              {pr.title}
-                            </Text>
-                          </Tooltip>
-                        </Link>
-                        <Flex ml="auto" align="center" gap="4">
-                          {pr.createdAt && weeksAgo(pr.updatedAt) > STALE_PR_WEEKS_THRESHOLD && weeksAgo(pr.createdAt) > OLD_PR_WEEKS_THRESHOLD && (
-                            <Tooltip content={`Old PR, created ${weeksAgo(pr.createdAt)} weeks ago with no updates for ${weeksAgo(pr.updatedAt)} weeks`}>
-                              <Text size="2">
-                                <LapTimerIcon color="gray" />
+                          <Flex ml="auto" align="center" gap="4">
+                            {updatedWeeksAgo !== null && createdWeeksAgo !== null &&
+                              updatedWeeksAgo > STALE_PR_WEEKS_THRESHOLD &&
+                              createdWeeksAgo > OLD_PR_WEEKS_THRESHOLD && (
+                                <Tooltip content={`Old PR, created ${createdWeeksAgo} weeks ago with no updates for ${updatedWeeksAgo} weeks`}>
+                                  <Text size="2">
+                                    <LapTimerIcon color="gray" />
+                                  </Text>
+                                </Tooltip>
+                              )}
+                            {(pr.reviews?.length ?? 0) > LOVE_PR_REVIEWS_THRESHOLD && (
+                              <Tooltip content={`Loved PR, Reviewed more than ${pr.reviews?.length ?? 0} times`}>
+                                <Text size="2">
+                                  <Image src={MinecraftHeart} alt="minecraft heart " width={12} height={12} />
+                                </Text>
+                              </Tooltip>
+                            )}
+                            <Tooltip content={pr.reviewDecision || 'No review decision'}>
+                              <Text className="sm:block hidden">
+                                {
+                                  REVIEW_DECISION_ICON_MAP[
+                                  (pr.reviewDecision &&
+                                    ['APPROVED', 'CHANGES_REQUESTED', 'REVIEW_REQUIRED'].includes(pr.reviewDecision)
+                                    ? pr.reviewDecision
+                                    : '') as 'APPROVED' | 'CHANGES_REQUESTED' | 'REVIEW_REQUIRED' | ''
+                                  ]
+                                }
                               </Text>
                             </Tooltip>
-                          )}
-                          {(pr.reviews?.length ?? 0) > LOVE_PR_REVIEWS_THRESHOLD && (
-                            <Tooltip content={`Loved PR, Reviewed more than ${pr.reviews?.length ?? 0} times`}>
-                              <Text size="2">
-                                <Image src={MinecraftHeart} alt="minecraft heart " width={12} height={12} />
-                              </Text>
-                            </Tooltip>
-                          )}
-                          <Tooltip content={pr.reviewDecision || 'No review decision'}>
-                            <Text className="sm:block hidden">
-                              {
-                                REVIEW_DECISION_ICON_MAP[
-                                (pr.reviewDecision &&
-                                  ['APPROVED', 'CHANGES_REQUESTED', 'REVIEW_REQUIRED'].includes(pr.reviewDecision)
-                                  ? pr.reviewDecision
-                                  : '') as 'APPROVED' | 'CHANGES_REQUESTED' | 'REVIEW_REQUIRED' | ''
-                                ]
-                              }
-                            </Text>
-                          </Tooltip>
-                          <HoverCard.Root>
-                            <HoverCard.Trigger>
-                              <IconButton variant="soft">
-                                <InfoCircledIcon />
-                              </IconButton>
-                            </HoverCard.Trigger>
-                            <HoverCard.Content width="360px">
-                              <Flex direction="column" gap="2" p="2">
-                                <Text size="2" weight="bold">
-                                  {pr.title}
-                                </Text>
-                                <Text size="1" weight="bold" color="gray">
-                                  PR #{pr.number} • {pr.state}
-                                </Text>
-                                <Text size="1" color="gray">
-                                  <Text weight="bold">Author: </Text> {pr.authorLogin}
-                                </Text>
-                                <Text size="1" color="gray">
-                                  <Text weight="bold">Review Decision: </Text> {pr.reviewDecision || 'N/A'}
-                                </Text>
-                                <Text size="1" color="gray">
-                                  <Text weight="bold">Created: </Text>{' '}
-                                  {pr.createdAt ? new Date(pr.createdAt).toLocaleString() : 'N/A'}
-                                </Text>
-                                <Text size="1" color="gray">
-                                  <Text weight="bold">Updated: </Text>{' '}
-                                  {pr.updatedAt ? new Date(pr.updatedAt).toLocaleString() : 'N/A'}
-                                </Text>
-                                <Text size="1" color="gray">
-                                  <Text weight="bold">URL: </Text>{' '}
-                                  <Link href={pr.url} target="_blank" rel="noopener noreferrer">
-                                    {pr.url}
-                                  </Link>
-                                </Text>
-                                <Text size="1" color="gray">
-                                  <Text weight="bold">Reviewed: </Text> {pr.reviews?.length} times
-                                </Text>
-                              </Flex>
-                            </HoverCard.Content>
-                          </HoverCard.Root>
+                            <HoverCard.Root>
+                              <HoverCard.Trigger>
+                                <IconButton variant="soft">
+                                  <InfoCircledIcon />
+                                </IconButton>
+                              </HoverCard.Trigger>
+                              <HoverCard.Content width="360px">
+                                <Flex direction="column" gap="2" p="2">
+                                  <Text size="2" weight="bold">
+                                    {pr.title}
+                                  </Text>
+                                  <Text size="1" weight="bold" color="gray">
+                                    PR #{pr.number} • {pr.state}
+                                  </Text>
+                                  <Text size="1" color="gray">
+                                    <Text weight="bold">Author: </Text> {pr.authorLogin}
+                                  </Text>
+                                  <Text size="1" color="gray">
+                                    <Text weight="bold">Review Decision: </Text> {pr.reviewDecision || 'N/A'}
+                                  </Text>
+                                  <Text size="1" color="gray">
+                                    <Text weight="bold">Created: </Text>{' '}
+                                    {pr.createdAt ? new Date(pr.createdAt).toLocaleString() : 'N/A'}
+                                  </Text>
+                                  <Text size="1" color="gray">
+                                    <Text weight="bold">Updated: </Text>{' '}
+                                    {pr.updatedAt ? new Date(pr.updatedAt).toLocaleString() : 'N/A'}
+                                  </Text>
+                                  <Text size="1" color="gray">
+                                    <Text weight="bold">URL: </Text>{' '}
+                                    <Link href={pr.url} target="_blank" rel="noopener noreferrer">
+                                      {pr.url}
+                                    </Link>
+                                  </Text>
+                                  <Text size="1" color="gray">
+                                    <Text weight="bold">Reviewed: </Text> {pr.reviews?.length} times
+                                  </Text>
+                                </Flex>
+                              </HoverCard.Content>
+                            </HoverCard.Root>
+                          </Flex>
                         </Flex>
-                      </Flex>
-                      <Separator size="4" />
-                    </li>
-                  ))}
+                        <Separator size="4" />
+                      </li>
+                    );
+                  })}
               </ul>
             </Box>
           ) : null,

--- a/src/components/features/report/repo-pr-status-list.tsx
+++ b/src/components/features/report/repo-pr-status-list.tsx
@@ -1,9 +1,11 @@
 import { TPullRequest } from '@/utils/schemas';
-import { CheckCircledIcon, ExclamationTriangleIcon, InfoCircledIcon, MixerHorizontalIcon, QuestionMarkCircledIcon } from '@radix-ui/react-icons';
+import { CheckCircledIcon, ExclamationTriangleIcon, InfoCircledIcon, LapTimerIcon, MixerHorizontalIcon, QuestionMarkCircledIcon } from '@radix-ui/react-icons';
 import { Avatar, Box, Flex, Heading, Link, Text, Tooltip, HoverCard, IconButton, Separator } from '@radix-ui/themes';
 import Image from 'next/image';
 import { Status, STATUS_ORDER } from './report-client-page';
 import MinecraftHeart from '@/images/minecraft-heart.png';
+import { differenceInWeeks } from 'date-fns';
+
 
 const STATUS_TOOLTIPS: Record<Status, string> = {
   blocked: 'PRs is technically mergeable but blocked.',
@@ -24,6 +26,12 @@ interface RepoPRStatusListProps {
   repo: string;
   statusMap: { [status: string]: TPullRequest[] };
   isOffline: boolean;
+}
+
+const weeksAgo = (dateString: string): number => {
+  const date = new Date(dateString);
+  const now = new Date();
+  return differenceInWeeks(now, date);
 }
 
 const RepoPRStatusList = ({ repo, statusMap, isOffline }: RepoPRStatusListProps) => {
@@ -94,6 +102,13 @@ const RepoPRStatusList = ({ repo, statusMap, isOffline }: RepoPRStatusListProps)
                           </Tooltip>
                         </Link>
                         <Flex ml="auto" align="center" gap="4">
+                          {pr.createdAt && weeksAgo(pr.createdAt) > 24 && (
+                            <Tooltip content={`Old PR, created ${weeksAgo(pr.createdAt)} weeks ago`}>
+                              <Text size="2">
+                                <LapTimerIcon color="gray" />
+                              </Text>
+                            </Tooltip>
+                          )}
                           {(pr.reviews?.length ?? 0) > 10 && (
                             <Tooltip content={`Loved PR, Reviewed more than ${pr.reviews?.length ?? 0} times`}>
                               <Text size="2">
@@ -105,10 +120,10 @@ const RepoPRStatusList = ({ repo, statusMap, isOffline }: RepoPRStatusListProps)
                             <Text className="sm:block hidden">
                               {
                                 REVIEW_DECISION_ICON_MAP[
-                                  (pr.reviewDecision &&
+                                (pr.reviewDecision &&
                                   ['APPROVED', 'CHANGES_REQUESTED', 'REVIEW_REQUIRED'].includes(pr.reviewDecision)
-                                    ? pr.reviewDecision
-                                    : '') as 'APPROVED' | 'CHANGES_REQUESTED' | 'REVIEW_REQUIRED' | ''
+                                  ? pr.reviewDecision
+                                  : '') as 'APPROVED' | 'CHANGES_REQUESTED' | 'REVIEW_REQUIRED' | ''
                                 ]
                               }
                             </Text>

--- a/src/components/features/report/repo-pr-status-list.tsx
+++ b/src/components/features/report/repo-pr-status-list.tsx
@@ -32,7 +32,7 @@ const weeksAgo = (dateString: string): number => {
   const date = new Date(dateString);
   const now = new Date();
   return differenceInWeeks(now, date);
-}
+};
 
 const RepoPRStatusList = ({ repo, statusMap, isOffline }: RepoPRStatusListProps) => {
   return (

--- a/src/components/features/report/repo-pr-status-list.tsx
+++ b/src/components/features/report/repo-pr-status-list.tsx
@@ -6,6 +6,9 @@ import { Status, STATUS_ORDER } from './report-client-page';
 import MinecraftHeart from '@/images/minecraft-heart.png';
 import { differenceInWeeks } from 'date-fns';
 
+const LOVE_PR_REVIEWS_THRESHOLD = 10;
+const OLD_PR_WEEKS_THRESHOLD = 24;
+const STALE_PR_WEEKS_THRESHOLD = 12;
 
 const STATUS_TOOLTIPS: Record<Status, string> = {
   blocked: 'PRs is technically mergeable but blocked.',
@@ -102,14 +105,14 @@ const RepoPRStatusList = ({ repo, statusMap, isOffline }: RepoPRStatusListProps)
                           </Tooltip>
                         </Link>
                         <Flex ml="auto" align="center" gap="4">
-                          {pr.createdAt && weeksAgo(pr.createdAt) > 24 && (
-                            <Tooltip content={`Old PR, created ${weeksAgo(pr.createdAt)} weeks ago`}>
+                          {pr.createdAt && weeksAgo(pr.updatedAt) > STALE_PR_WEEKS_THRESHOLD && weeksAgo(pr.createdAt) > OLD_PR_WEEKS_THRESHOLD && (
+                            <Tooltip content={`Old PR, created ${weeksAgo(pr.createdAt)} weeks ago with no updates for ${weeksAgo(pr.updatedAt)} weeks`}>
                               <Text size="2">
                                 <LapTimerIcon color="gray" />
                               </Text>
                             </Tooltip>
                           )}
-                          {(pr.reviews?.length ?? 0) > 10 && (
+                          {(pr.reviews?.length ?? 0) > LOVE_PR_REVIEWS_THRESHOLD && (
                             <Tooltip content={`Loved PR, Reviewed more than ${pr.reviews?.length ?? 0} times`}>
                               <Text size="2">
                                 <Image src={MinecraftHeart} alt="minecraft heart " width={12} height={12} />

--- a/src/components/features/report/repo-pr-status-list.tsx
+++ b/src/components/features/report/repo-pr-status-list.tsx
@@ -112,12 +112,12 @@ const RepoPRStatusList = ({ repo, statusMap, isOffline }: RepoPRStatusListProps)
                             {updatedWeeksAgo !== null && createdWeeksAgo !== null &&
                               updatedWeeksAgo > STALE_PR_WEEKS_THRESHOLD &&
                               createdWeeksAgo > OLD_PR_WEEKS_THRESHOLD && (
-                                <Tooltip content={`Old PR, created ${createdWeeksAgo} weeks ago with no updates for ${updatedWeeksAgo} weeks`}>
-                                  <Text size="2">
-                                    <LapTimerIcon color="gray" />
-                                  </Text>
-                                </Tooltip>
-                              )}
+                              <Tooltip content={`Old PR, created ${createdWeeksAgo} weeks ago with no updates for ${updatedWeeksAgo} weeks`}>
+                                <Text size="2">
+                                  <LapTimerIcon color="gray" />
+                                </Text>
+                              </Tooltip>
+                            )}
                             {(pr.reviews?.length ?? 0) > LOVE_PR_REVIEWS_THRESHOLD && (
                               <Tooltip content={`Loved PR, Reviewed more than ${pr.reviews?.length ?? 0} times`}>
                                 <Text size="2">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds an "Old PR" indicator: PRs exceeding age and inactivity thresholds show a lap-timer icon with tooltip like “Old PR, created X weeks ago” including inactivity info.
  * Adds a "Loved PR" indicator: PRs with many reviews show a heart icon with tooltip.
  * Adjusts review-decision icon placement and row layout to accommodate new indicators while preserving hover-based PR detail panels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->