### PR TITLE
fix: rename mr keyword to pr

### DIFF
--- a/src/components/features/scoreboard/scoreboard-page.tsx
+++ b/src/components/features/scoreboard/scoreboard-page.tsx
@@ -21,7 +21,7 @@ import useGetLastIssues from '@/hooks/use-get-last-issues';
 import useGetMilestone from '@/hooks/use-get-milestone';
 import useGetNewContributors from '@/hooks/use-get-new-contributors';
 
-import { getLastMRs, TimeFilter } from '@/utils/github';
+import { getLastPRs, TimeFilter } from '@/utils/github';
 
 import REPOSITORY from '@/constants/repository';
 
@@ -41,7 +41,7 @@ const ScoreboardPage = ({ videos }: { videos?: TYoutubeVideoPlaylist }) => {
   const { data: issues, isPending: isIssuesPending } = useGetLastIssues();
   const { data: newContributors, isPending: isNewContributorsPending } = useGetNewContributors();
 
-  const lastMRs = useMemo(() => getLastMRs(allTimeContributors ?? [], 5), [allTimeContributors]);
+  const lastPRs = useMemo(() => getLastPRs(allTimeContributors ?? [], 5), [allTimeContributors]);
 
   const { isOffline } = useOffline();
 
@@ -91,7 +91,7 @@ const ScoreboardPage = ({ videos }: { videos?: TYoutubeVideoPlaylist }) => {
           <Heading as="h2" weight="bold" size="6" mt="6">
             ✔️ Freshly Merged
           </Heading>
-          {isAllTimePending ? <Loader /> : <PrsTable prs={lastMRs} />}
+          {isAllTimePending ? <Loader /> : <PrsTable prs={lastPRs} />}
         </Flex>
 
         <Flex direction="column" gap="4">

--- a/src/components/modules/contributions-dialog.tsx
+++ b/src/components/modules/contributions-dialog.tsx
@@ -121,7 +121,7 @@ const ContributionsDialog = ({ user, children, ...props }: ContributionsDialogPr
                 </Table.Row>
                 <Table.Row>
                   <Table.RowHeaderCell>
-                    <Text size="1">Reviewed MRs score</Text>
+                    <Text size="1">Reviewed PRs score</Text>
                   </Table.RowHeaderCell>
                   <Table.Cell align="right">
                     <Text size="1">{user.TotalReviewedPullRequests * (scoreFactors?.reviewedPrFactor ?? 0)} points</Text>

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -61,11 +61,11 @@ export const cmpUpdatedAt = <T extends { createdAt: string | Date }>(objA: T, ob
 };
 
 /**
- * Get the last MRs from a list of contributors
+ * Get the last PRs from a list of contributors
  * @param contributors The contributors
- * @param last The number of MRs to get
+ * @param last The number of PRs to get
  */
-export const getLastMRs = (contributors: TEnhancedUserWithStats[], last: number) => {
+export const getLastPRs = (contributors: TEnhancedUserWithStats[], last: number) => {
   const prs = contributors
     .map(({ pullRequests }) => pullRequests)
     .filter(isDefined)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Updated UI terminology from “MRs” to “PRs” across the Scoreboard and Contributions dialog for consistency.
  - “Freshly Merged” section now displays recent PRs, and the contribution score label reads “Reviewed PRs score.”
  - No behavioral changes; data loading and display remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->