### PR TITLE
chore: update go version in dockerfile

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,5 +1,5 @@
 # Start from the latest golang base image
-FROM golang:1.23-bullseye
+FROM golang:1.24
 
 # Set the Current Working Directory inside the container
 WORKDIR /app


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded the Go runtime in the server container image to version 1.24.
  * Build and deployment steps remain unchanged.
  * No changes to user-facing functionality or interfaces.
  * Existing configurations, environment variables, and startup behavior are unchanged.
  * No action required for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->