### PR TITLE
chore: remove vercel analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,6 @@
     "@radix-ui/themes": "^3.1.3",
     "@tanstack/react-query": "^5.64.2",
     "@types/papaparse": "^5.3.16",
-    "@vercel/analytics": "^1.5.0",
-    "@vercel/kv": "^3.0.0",
     "autoprefixer": "^10.4.19",
     "clsx": "^2.1.1",
     "cross-env": "^7.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,12 +50,6 @@ dependencies:
   '@types/papaparse':
     specifier: ^5.3.16
     version: 5.3.16
-  '@vercel/analytics':
-    specifier: ^1.5.0
-    version: 1.5.0(next@14.2.33)(react@18.3.1)
-  '@vercel/kv':
-    specifier: ^3.0.0
-    version: 3.0.0
   autoprefixer:
     specifier: ^10.4.19
     version: 10.4.21(postcss@8.5.6)
@@ -3607,49 +3601,6 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
-
-  /@upstash/redis@1.35.4:
-    resolution: {integrity: sha512-WE1ZnhFyBiIjTDW13GbO6JjkiMVVjw5VsvS8ENmvvJsze/caMQ5paxVD44+U68IUVmkXcbsLSoE+VIYsHtbQEw==}
-    dependencies:
-      uncrypto: 0.1.3
-    dev: false
-
-  /@vercel/analytics@1.5.0(next@14.2.33)(react@18.3.1):
-    resolution: {integrity: sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==}
-    peerDependencies:
-      '@remix-run/react': ^2
-      '@sveltejs/kit': ^1 || ^2
-      next: '>= 13'
-      react: ^18 || ^19 || ^19.0.0-rc
-      svelte: '>= 4'
-      vue: ^3
-      vue-router: ^4
-    peerDependenciesMeta:
-      '@remix-run/react':
-        optional: true
-      '@sveltejs/kit':
-        optional: true
-      next:
-        optional: true
-      react:
-        optional: true
-      svelte:
-        optional: true
-      vue:
-        optional: true
-      vue-router:
-        optional: true
-    dependencies:
-      next: 14.2.33(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-    dev: false
-
-  /@vercel/kv@3.0.0:
-    resolution: {integrity: sha512-pKT8fRnfyYk2MgvyB6fn6ipJPCdfZwiKDdw7vB+HL50rjboEBHDVBEcnwfkEpVSp2AjNtoaOUH7zG+bVC/rvSg==}
-    engines: {node: '>=14.6'}
-    dependencies:
-      '@upstash/redis': 1.35.4
-    dev: false
 
   /@web3auth/auth-adapter@9.5.3(@babel/runtime@7.28.4):
     resolution: {integrity: sha512-wVD3IJq4WLh1A19DJwh2IyqgzCwMT+5QGSPMIj+/JjGCHnshDCgUCF0kMdufLDUxhZD37J71lU4wpfdj8AxGDQ==}
@@ -8259,10 +8210,6 @@ packages:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
-
-  /uncrypto@0.1.3:
-    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
-    dev: false
 
   /undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,5 @@
 import { ReactNode } from 'react';
 
-import { Analytics } from '@vercel/analytics/next';
 import type { Metadata } from 'next';
 import { ThemeProvider } from 'next-themes';
 
@@ -190,7 +189,6 @@ const RootLayout = ({ children, details }: RootLayoutProps) => {
               </ThemeProvider>
             </QueryClientWrapper>
             <OfflineBanner />
-            <Analytics />
           </OfflineProvider>
         </AuthProvider>
       </body>


### PR DESCRIPTION
Since we're moving to Netlify, this package is obsolete for our project.