### PR TITLE
fix: disable scroll to top after appending searchParams

### DIFF
--- a/src/components/features/scoreboard/scoreboard.tsx
+++ b/src/components/features/scoreboard/scoreboard.tsx
@@ -70,7 +70,7 @@ const Scoreboard = ({ ...props }: FlexProps) => {
     const currentParams = searchParams.toString();
     if (urlParams === currentParams) return;
 
-    router.replace(`?${urlParams}`);
+    router.replace(`?${urlParams}`, { scroll: false });
   }, [timeFilter, exclude, selectedRepositories, router, searchParams, buildSearchParams]);
 
   useEffect(() => {


### PR DESCRIPTION
This fixes the following behaviour : On the scoreboard (home) page, when appending searchParams to the URL, the user gets automatically scrolled to the top of the page. We don't want that, as it breaks its navigation.