### PR TITLE
feat: make fetch calls ISR

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -43,6 +43,10 @@ import TEAMS from '@/constants/teams';
 import ENV from '@/env';
 import { auth } from '@clerk/nextjs/server';
 
+const REVALIDATE_SHORT = 60 * 5; // 5 minutes
+const REVALIDATE_MEDIUM = 60 * 15; // 15 minutes
+const REVALIDATE_LONG = 60 * 60; // 1 hour
+
 export const getContributors = async (timeFilter: TimeFilter, excludeCoreTeam?: boolean, repositories?: string[]) => {
   const url = new URL('/stats', ENV.NEXT_PUBLIC_API_URL);
 
@@ -55,7 +59,7 @@ export const getContributors = async (timeFilter: TimeFilter, excludeCoreTeam?: 
 
   if (repositories) url.searchParams.append('repositories', repositories.join(','));
 
-  const data = await fetchJson(url.toString(), { cache: 'no-cache' });
+  const data = await fetchJson(url.toString(), { next: { revalidate: REVALIDATE_SHORT } });
 
   return z.array(EnhancedUserWithStatsSchema).parse(data);
 };
@@ -155,7 +159,7 @@ export const updateReportHour = async (payload: { hour: number; minute: number; 
 export const getLastIssues = async (last: number) => {
   const url = new URL('/issues?labels=help wanted,bounty', ENV.NEXT_PUBLIC_API_URL);
 
-  const data = await fetchJson(url.toString(), { cache: 'no-cache' });
+  const data = await fetchJson(url.toString(), { next: { revalidate: REVALIDATE_SHORT } });
 
   return z.array(IssueSchema).parse(data).slice(0, last);
 };
@@ -174,7 +178,7 @@ export const getPullrequestsReportByDate = async (startDate: Date, endDate: Date
 export const getNewContributors = async () => {
   const url = new URL('/contributors/newest?number=5', ENV.NEXT_PUBLIC_API_URL);
 
-  const data = await fetchJson(url.toString(), { cache: 'no-cache' });
+  const data = await fetchJson(url.toString(), { next: { revalidate: REVALIDATE_SHORT } });
 
   return z.array(UserSchema).parse(data);
 };
@@ -182,7 +186,7 @@ export const getNewContributors = async () => {
 export const getMilestone = async () => {
   const url = new URL(`/milestones/${MILESTONE.number}`, ENV.NEXT_PUBLIC_API_URL);
 
-  const data = await fetchJson(url.toString(), { cache: 'no-cache' });
+  const data = await fetchJson(url.toString(), { next: { revalidate: REVALIDATE_LONG } });
 
   return MilestoneSchema.parse(data);
 };
@@ -190,7 +194,7 @@ export const getMilestone = async () => {
 export const getRepositories = async () => {
   const url = new URL('/repositories', ENV.NEXT_PUBLIC_API_URL);
 
-  const data = await fetchJson(url.toString(), { cache: 'no-cache' });
+  const data = await fetchJson(url.toString(), { next: { revalidate: REVALIDATE_MEDIUM } });
 
   return z.array(RepositorySchema).parse(data);
 };
@@ -198,7 +202,7 @@ export const getRepositories = async () => {
 export const getContributor = async (login: string) => {
   const url = new URL(`/contributors/${login}`, ENV.NEXT_PUBLIC_API_URL);
 
-  const data = await fetchJson(url.toString(), { cache: 'no-cache' });
+  const data = await fetchJson(url.toString(), { next: { revalidate: REVALIDATE_SHORT } });
 
   return ContributorSchema.parse(data);
 };
@@ -206,7 +210,7 @@ export const getContributor = async (login: string) => {
 export const getPackages = async () => {
   const url = new URL('/onchain/packages', ENV.NEXT_PUBLIC_API_URL);
 
-  const data = await fetchJson(url.toString(), { cache: 'no-cache' });
+  const data = await fetchJson(url.toString(), { next: { revalidate: REVALIDATE_MEDIUM } });
 
   return PackagesSchema.parse(data);
 };
@@ -215,7 +219,7 @@ export const getPackagesByUser = async (address: string) => {
   if (!address) return [];
   const url = new URL(`/onchain/packages/${address}`, ENV.NEXT_PUBLIC_API_URL);
 
-  const data = await fetchJson(url.toString(), { cache: 'no-cache' });
+  const data = await fetchJson(url.toString(), { next: { revalidate: REVALIDATE_MEDIUM } });
 
   return PackagesSchema.parse(data);
 };
@@ -223,7 +227,7 @@ export const getPackagesByUser = async (address: string) => {
 export const getNamespaces = async () => {
   const url = new URL('/onchain/namespaces', ENV.NEXT_PUBLIC_API_URL);
 
-  const data = await fetchJson(url.toString(), { cache: 'no-cache' });
+  const data = await fetchJson(url.toString(), { next: { revalidate: REVALIDATE_MEDIUM } });
 
   return NamespacesSchema.parse(data);
 };
@@ -231,7 +235,7 @@ export const getNamespaces = async () => {
 export const getNamespacesByUser = async (address: string) => {
   const url = new URL(`/onchain/namespaces/${address}`, ENV.NEXT_PUBLIC_API_URL);
 
-  const data = await fetchJson(url.toString(), { cache: 'no-cache' });
+  const data = await fetchJson(url.toString(), { next: { revalidate: REVALIDATE_MEDIUM } });
 
   return NamespacesSchema.parse(data);
 };
@@ -241,8 +245,7 @@ export const getProposals = async (address?: string) => {
   const url = new URL('/onchain/proposals', ENV.NEXT_PUBLIC_API_URL);
   if (address) url.searchParams.set('address', address);
 
-  const res = await fetch(url.toString(), { cache: 'no-cache' });
-  const data = await res.json();
+  const data = await fetchJson(url.toString(), { next: { revalidate: REVALIDATE_MEDIUM } });
 
   return ProposalsSchema.parse(data);
 };
@@ -251,8 +254,7 @@ export const getProposals = async (address?: string) => {
 export const getGovdaoMembers = async () => {
   const url = new URL('/onchain/govdao-members', ENV.NEXT_PUBLIC_API_URL);
 
-  const res = await fetch(url.toString(), { cache: 'no-cache' });
-  const data = await res.json();
+  const data = await fetchJson(url.toString(), { next: { revalidate: REVALIDATE_MEDIUM } });
 
   return GovdaoMembersSchema.parse(data);
 };
@@ -275,7 +277,7 @@ export const getProposal = async (id: string) => {
 export const getScoreFactors = async () => {
   const url = new URL('/score-factors', ENV.NEXT_PUBLIC_API_URL);
 
-  const data = await fetchJson(url.toString(), { cache: 'no-cache' });
+  const data = await fetchJson(url.toString(), { next: { revalidate: REVALIDATE_LONG } });
 
   return ScoreFactorsSchema.parse(data);
 };

--- a/src/utils/fetcher.ts
+++ b/src/utils/fetcher.ts
@@ -12,7 +12,9 @@ export class HttpError extends Error {
   }
 }
 
-export async function fetchJson<T = unknown>(url: string | URL, init?: RequestInit): Promise<T> {
+type NextRequestInit = RequestInit & { next?: { revalidate?: number; tags?: string[] } };
+
+export async function fetchJson<T = unknown>(url: string | URL, init?: NextRequestInit): Promise<T> {
   const res = await fetch(typeof url === 'string' ? url : url.toString(), init);
   if (!res.ok) {
     const bodyText = await res.text();


### PR DESCRIPTION
I realised on Netlify that a lot of our serverless calls consumed a ton of bandwidth, so I decided to cache / revalidate through ISR most of our fetch calls