### PR TITLE
chore: disable next image optimizer for now

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,7 @@
 const nextConfig = {
   reactStrictMode: true,
   images: {
+    unoptimized: true,
     remotePatterns: [
       {
         protocol: 'https',


### PR DESCRIPTION
We aim to reduce bandwidth consumption in Netlify. For now, we will disable image optimisation (for images coming from github and youtube) and monitor if the changes our bandwidth consumption on Netlify