### PR TITLE
fix: tweak page number of prs

### DIFF
--- a/server/sync/sync.go
+++ b/server/sync/sync.go
@@ -206,7 +206,7 @@ func (s *Syncer) syncPRs(repository models.Repository) error {
 					EndCursor   githubv4.String
 					HasNextPage bool
 				}
-			} `graphql:"pullRequests(first: 100 after:$cursor orderBy: { field: UPDATED_AT, direction: DESC } )"`
+			} `graphql:"pullRequests(first: 50 after:$cursor orderBy: { field: UPDATED_AT, direction: DESC } )"`
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
 


### PR DESCRIPTION
We recently had 502 errors during the sync job.
`2025-12-01T16:49:15.902+0100    DEBUG   sync/sync.go:43 HTTP request    {"method": "POST", "url": "https://api.github.com/graphql", "headers": {"Content-Type":["application/json"]}}
2025-12-01T16:49:26.291+0100    ERROR   sync/sync.go:80 HTTP response   {"status": "502 Bad Gateway", "url": "https://api.github.com/graphql", "rate_limit_remaining": "", "rate_limit_limit": "", "rate_limit_reset": "", "body_preview": "<html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n<hr><center>nginx</center>\r\n</body>\r\n</html>\r\n"}`
`2025-12-01T16:49:26.292+0100    ERROR   sync/sync.go:172        error while syncing PRs pullRequests query failed for gnolang/gno (cursor=<nil>): non-200 OK status code: 502 Bad Gateway body: "<html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n<hr><center>nginx</center>\r\n</body>\r\n</html>\r\n"`

These 502 errors happened especially for the gnolang/gno repository sync. From what I understand, they happen because the proxy server between us and the GitHub graphql endpoint hiccups because of the number of items returned by the API. Also, this repository has a TON of PRs, which probably plays a role in this bug.

Therefore, this PR is an attempt to solve this to at least reduce the number of items returned by the API for each page. Let me know what you think!