### PR TITLE
feat(sync): Phase 2a backend hardening — worker pool + incremental refresh + parser

### DIFF
--- a/server/models/repository.go
+++ b/server/models/repository.go
@@ -13,23 +13,49 @@ type Repository struct {
 	BaseBranch string `json:"baseBranch"`
 }
 
+// GetRepositoriesFromConfig parses GITHUB_REPOSITORIES from the environment.
+// Format: each repo is `owner/name/branch`. Repos can be separated by spaces,
+// commas, or newlines (mix-and-match supported). Blank entries are skipped.
 func GetRepositoriesFromConfig() ([]Repository, error) {
-	repositoriesCfg := strings.Split(os.Getenv("GITHUB_REPOSITORIES"), " ")
-	repositories := make([]Repository, len(repositoriesCfg))
-	for index, repository := range repositoriesCfg {
-		parts := strings.Split(repository, "/")
-		if len(parts) != 3 {
-			return nil, fmt.Errorf("invalid repository %s", repository)
+	return ParseRepositoriesConfig(os.Getenv("GITHUB_REPOSITORIES"))
+}
+
+// ParseRepositoriesConfig is the env-free core, exposed for tests.
+//
+// Tolerated separators: ' ', ',', '\n', '\t', '\r'. Entries are trimmed.
+// Errors are returned with 1-based entry index and the offending string so
+// a bad deploy is easy to debug from the gnolove server log.
+func ParseRepositoriesConfig(cfg string) ([]Repository, error) {
+	tokens := strings.FieldsFunc(cfg, func(r rune) bool {
+		switch r {
+		case ' ', ',', '\n', '\t', '\r':
+			return true
 		}
-		repositories[index] = Repository{
-			ID:         parts[0] + "/" + parts[1], // without base branch
+		return false
+	})
+
+	out := make([]Repository, 0, len(tokens))
+	idx := 0
+	for _, raw := range tokens {
+		entry := strings.TrimSpace(raw)
+		if entry == "" {
+			continue
+		}
+		idx++
+		parts := strings.Split(entry, "/")
+		if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+			return nil, fmt.Errorf("invalid repository entry %d (%q): expected owner/name/branch", idx, entry)
+		}
+		out = append(out, Repository{
+			ID:         parts[0] + "/" + parts[1],
 			Name:       parts[1],
 			Owner:      parts[0],
 			BaseBranch: parts[2],
-		}
+		})
 	}
 
-	fmt.Println(repositories)
-
-	return repositories, nil
+	if len(out) == 0 {
+		return nil, fmt.Errorf("GITHUB_REPOSITORIES is empty or has no valid entries")
+	}
+	return out, nil
 }

--- a/server/models/repository_test.go
+++ b/server/models/repository_test.go
@@ -1,0 +1,100 @@
+package models
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseRepositoriesConfig_SpaceSeparated(t *testing.T) {
+	got, err := ParseRepositoriesConfig("gnolang/gno/master onbloc/gnoscan/main")
+	if err != nil {
+		t.Fatalf("ParseRepositoriesConfig: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d repos, want 2", len(got))
+	}
+	if got[0].ID != "gnolang/gno" || got[0].BaseBranch != "master" {
+		t.Errorf("first repo = %+v", got[0])
+	}
+	if got[1].ID != "onbloc/gnoscan" || got[1].BaseBranch != "main" {
+		t.Errorf("second repo = %+v", got[1])
+	}
+}
+
+func TestParseRepositoriesConfig_CommaSeparated(t *testing.T) {
+	got, err := ParseRepositoriesConfig("gnolang/gno/master,onbloc/gnoscan/main")
+	if err != nil {
+		t.Fatalf("ParseRepositoriesConfig: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d repos, want 2", len(got))
+	}
+}
+
+func TestParseRepositoriesConfig_NewlineSeparated(t *testing.T) {
+	got, err := ParseRepositoriesConfig("gnolang/gno/master\nonbloc/gnoscan/main\n")
+	if err != nil {
+		t.Fatalf("ParseRepositoriesConfig: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d repos, want 2", len(got))
+	}
+}
+
+func TestParseRepositoriesConfig_MixedSeparators(t *testing.T) {
+	got, err := ParseRepositoriesConfig("gnolang/gno/master, onbloc/gnoscan/main\nsamouraiworld/gnolove/main")
+	if err != nil {
+		t.Fatalf("ParseRepositoriesConfig: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d repos (%v), want 3", len(got), got)
+	}
+}
+
+func TestParseRepositoriesConfig_IgnoresBlankEntries(t *testing.T) {
+	// Trailing comma, doubled commas, surrounding whitespace.
+	got, err := ParseRepositoriesConfig("  gnolang/gno/master ,, , onbloc/gnoscan/main,\n\n")
+	if err != nil {
+		t.Fatalf("ParseRepositoriesConfig: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d repos, want 2", len(got))
+	}
+}
+
+func TestParseRepositoriesConfig_ErrorIncludesPositionAndEntry(t *testing.T) {
+	_, err := ParseRepositoriesConfig("gnolang/gno/master, broken-entry, onbloc/gnoscan/main")
+	if err == nil {
+		t.Fatal("want parse error, got nil")
+	}
+	if !strings.Contains(err.Error(), "broken-entry") {
+		t.Errorf("error missing entry context: %v", err)
+	}
+	if !strings.Contains(err.Error(), "entry 2") {
+		t.Errorf("error missing entry index: %v", err)
+	}
+}
+
+func TestParseRepositoriesConfig_RejectsEmptyConfig(t *testing.T) {
+	if _, err := ParseRepositoriesConfig(""); err == nil {
+		t.Error("empty config should error")
+	}
+	if _, err := ParseRepositoriesConfig("   \n  ,, "); err == nil {
+		t.Error("whitespace-only config should error")
+	}
+}
+
+func TestParseRepositoriesConfig_RejectsEmptyComponents(t *testing.T) {
+	cases := []string{
+		"/gno/master",       // empty owner
+		"gnolang//master",   // empty name
+		"gnolang/gno/",      // empty branch
+		"gnolang/gno",       // only two segments
+		"gnolang/gno/a/b",   // too many segments
+	}
+	for _, c := range cases {
+		if _, err := ParseRepositoriesConfig(c); err == nil {
+			t.Errorf("ParseRepositoriesConfig(%q) should error", c)
+		}
+	}
+}

--- a/server/models/user.go
+++ b/server/models/user.go
@@ -22,6 +22,11 @@ type User struct {
 	Followers       int       `json:"followers"`
 	Following       int       `json:"following"`
 
+	// DetailsSyncedAt records when syncUserDetails last refreshed this user's
+	// profile fields (bio, top repos, follower counts). Zero means never.
+	// Used by Phase 2a's incremental refresh to skip users seen recently.
+	DetailsSyncedAt time.Time `gorm:"index" json:"detailsSyncedAt"`
+
 	Issues       []Issue       `gorm:"foreignKey:AuthorID" json:"issues"`
 	PullRequests []PullRequest `gorm:"foreignKey:AuthorID" json:"pullRequests"`
 	Reviews      []Review      `gorm:"foreignKey:AuthorID" json:"reviews"`

--- a/server/sync/backoff.go
+++ b/server/sync/backoff.go
@@ -1,0 +1,90 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// defaultSyncWorkers is the per-cycle concurrent repository count when the
+// SYNC_WORKERS env var is unset. Tuned to four — high enough to amortise
+// GitHub round-trip latency across ~50 repos, low enough to keep sqlite
+// writer contention bounded.
+const defaultSyncWorkers = 4
+
+// syncWorkerCount reads SYNC_WORKERS, clamped to [1, 16]. Out-of-range or
+// non-numeric values fall back to the default — same fail-closed posture
+// as the user-details interval.
+func syncWorkerCount() int {
+	raw := os.Getenv("SYNC_WORKERS")
+	if raw == "" {
+		return defaultSyncWorkers
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 1 {
+		return defaultSyncWorkers
+	}
+	if n > 16 {
+		return 16
+	}
+	return n
+}
+
+const (
+	defaultBackoffAttempts = 4
+	defaultBackoffBase     = 2 * time.Second
+)
+
+// isRateLimitErr matches the error strings GitHub's GraphQL endpoint returns
+// when we trip its primary or secondary rate limit. Keep this list narrow
+// so we don't accidentally retry-loop on real errors.
+func isRateLimitErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "rate limit"),
+		strings.Contains(msg, "secondary rate"),
+		strings.Contains(msg, "abuse detection"),
+		strings.Contains(msg, "403 forbidden"):
+		return true
+	}
+	return false
+}
+
+// backoffRetry runs fn up to attempts times with exponential delay, but only
+// re-runs when isRetryable(err) is true. Returns the last error if exhausted.
+// ctx cancellation aborts immediately.
+func backoffRetry(ctx context.Context, attempts int, base time.Duration, isRetryable func(error) bool, fn func() error) error {
+	if attempts < 1 {
+		attempts = 1
+	}
+	var lastErr error
+	for i := 0; i < attempts; i++ {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		err := fn()
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if !isRetryable(err) || i == attempts-1 {
+			return err
+		}
+		delay := base * time.Duration(1<<i) // 2s, 4s, 8s, ...
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+	if lastErr == nil {
+		lastErr = errors.New("backoffRetry: exhausted with no recorded error")
+	}
+	return lastErr
+}

--- a/server/sync/backoff_test.go
+++ b/server/sync/backoff_test.go
@@ -1,0 +1,114 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestSyncWorkerCount_DefaultAndEnv(t *testing.T) {
+	t.Setenv("SYNC_WORKERS", "")
+	if got := syncWorkerCount(); got != defaultSyncWorkers {
+		t.Errorf("default = %d, want %d", got, defaultSyncWorkers)
+	}
+	t.Setenv("SYNC_WORKERS", "8")
+	if got := syncWorkerCount(); got != 8 {
+		t.Errorf("env=8 → %d, want 8", got)
+	}
+	t.Setenv("SYNC_WORKERS", "100")
+	if got := syncWorkerCount(); got != 16 {
+		t.Errorf("env=100 → %d, want 16 (clamp)", got)
+	}
+	for _, raw := range []string{"nope", "0", "-3"} {
+		t.Run(raw, func(t *testing.T) {
+			os.Setenv("SYNC_WORKERS", raw)
+			defer os.Unsetenv("SYNC_WORKERS")
+			if got := syncWorkerCount(); got != defaultSyncWorkers {
+				t.Errorf("%q → %d, want default", raw, got)
+			}
+		})
+	}
+}
+
+func TestIsRateLimitErr(t *testing.T) {
+	cases := []struct {
+		err  error
+		want bool
+	}{
+		{nil, false},
+		{errors.New("API rate limit exceeded for user X"), true},
+		{errors.New("You have exceeded a secondary rate limit"), true},
+		{errors.New("403 Forbidden: abuse detection mechanism"), true},
+		{errors.New("404 not found"), false},
+		{errors.New("connection reset"), false},
+	}
+	for _, c := range cases {
+		if got := isRateLimitErr(c.err); got != c.want {
+			t.Errorf("isRateLimitErr(%v) = %v, want %v", c.err, got, c.want)
+		}
+	}
+}
+
+func TestBackoffRetry_RetriesUntilSuccess(t *testing.T) {
+	var calls int32
+	err := backoffRetry(context.Background(), 4, time.Millisecond, isRateLimitErr, func() error {
+		n := atomic.AddInt32(&calls, 1)
+		if n < 3 {
+			return errors.New("API rate limit exceeded")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("calls = %d, want 3", calls)
+	}
+}
+
+func TestBackoffRetry_DoesNotRetryNonRetryable(t *testing.T) {
+	var calls int32
+	got := backoffRetry(context.Background(), 4, time.Millisecond, isRateLimitErr, func() error {
+		atomic.AddInt32(&calls, 1)
+		return errors.New("404 not found")
+	})
+	if got == nil || got.Error() != "404 not found" {
+		t.Errorf("err = %v, want '404 not found'", got)
+	}
+	if calls != 1 {
+		t.Errorf("calls = %d, want 1 (no retry)", calls)
+	}
+}
+
+func TestBackoffRetry_ExhaustsAndReturnsLastErr(t *testing.T) {
+	var calls int32
+	err := backoffRetry(context.Background(), 3, time.Millisecond, isRateLimitErr, func() error {
+		atomic.AddInt32(&calls, 1)
+		return errors.New("API rate limit exceeded")
+	})
+	if err == nil {
+		t.Fatal("want error")
+	}
+	if calls != 3 {
+		t.Errorf("calls = %d, want 3", calls)
+	}
+}
+
+func TestBackoffRetry_CtxCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var calls int32
+	err := backoffRetry(ctx, 4, 50*time.Millisecond, isRateLimitErr, func() error {
+		atomic.AddInt32(&calls, 1)
+		return errors.New("API rate limit exceeded")
+	})
+	if err == nil {
+		t.Error("want context error")
+	}
+	if calls > 1 {
+		t.Errorf("calls = %d, want 0 or 1 (ctx cancelled)", calls)
+	}
+}

--- a/server/sync/sync.go
+++ b/server/sync/sync.go
@@ -80,34 +80,7 @@ func (s *Syncer) StartSynchonizing(ctx context.Context) error {
 		ticker := time.NewTicker(2 * time.Hour)
 		defer ticker.Stop()
 		for {
-			for _, repository := range s.repositories {
-				fmt.Printf("repository: %#v", repository)
-				s.logger.Info("Starting synchronization for ", repository.ID)
-				err := s.syncUsers(repository)
-				if err != nil {
-					s.logger.Errorf("error while syncing users %s", err.Error())
-				}
-
-				err = s.syncIssues(repository)
-				if err != nil {
-					s.logger.Errorf("error while syncing issues %s", err.Error())
-				}
-
-				err = s.syncPRs(repository)
-				if err != nil {
-					s.logger.Errorf("error while syncing PRs %s", err.Error())
-				}
-
-				err = s.syncMilestones(repository)
-				if err != nil {
-					s.logger.Errorf("error while syncing Milestones %s", err.Error())
-				}
-
-				err = s.syncCommits(repository)
-				if err != nil {
-					s.logger.Errorf("error while syncing commits %s", err.Error())
-				}
-			}
+			s.syncRepositoriesConcurrently(ctx)
 
 			// For some reason github api doesn't return all users. so we have to sync them manually
 			// by taking the ids from pull requests and issues without a corresponding ID on users table

--- a/server/sync/sync.go
+++ b/server/sync/sync.go
@@ -580,13 +580,25 @@ func (s *Syncer) syncCommits(repository models.Repository) error {
 	return nil
 }
 
-// syncUserDetails fetches and updates detailed GitHub data for all users
+// syncUserDetails refreshes GitHub profile fields (bio, top repos, follower
+// counts) for stale users only. A user is "stale" if their DetailsSyncedAt is
+// older than userDetailsRefreshInterval (default 7d) or zero (never synced).
+//
+// Pre-Phase-2a this loop was O(N_users) every sync cycle and a known scaling
+// risk (plan §11 R-2). The 7d window keeps profile drift bounded while
+// shrinking each cycle's GraphQL traffic to "new contributors + weekly slice".
 func (s *Syncer) syncUserDetails() error {
-	var users []models.User
-	if err := s.db.Find(&users).Error; err != nil {
-		s.logger.Errorf("Failed to fetch users for details sync: %v", err)
+	cutoff := time.Now().UTC().Add(-userDetailsRefreshInterval())
+	users, err := selectStaleUsers(s.db, cutoff)
+	if err != nil {
+		s.logger.Errorf("Failed to fetch stale users for details sync: %v", err)
 		return err
 	}
+	if len(users) == 0 {
+		s.logger.Info("User details sync: nothing stale.")
+		return nil
+	}
+	s.logger.Infof("User details sync: refreshing %d stale users (cutoff=%s).", len(users), cutoff.Format(time.RFC3339))
 
 	for _, user := range users {
 		var q struct {
@@ -687,6 +699,11 @@ func (s *Syncer) syncUserDetails() error {
 				user.TopRepositories = string(topReposJSON)
 			}
 		}
+
+		// Stamp the refresh time so the next cycle skips this user for ~7d.
+		// Done only on the happy path so transient GitHub errors above keep
+		// the user "stale" and we'll retry next cycle.
+		user.DetailsSyncedAt = time.Now().UTC()
 
 		if err := s.db.Save(&user).Error; err != nil {
 			s.logger.Errorf("Failed to update user %s: %v", user.Login, err)

--- a/server/sync/user_details.go
+++ b/server/sync/user_details.go
@@ -1,0 +1,40 @@
+package sync
+
+import (
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/samouraiworld/topofgnomes/server/models"
+	"gorm.io/gorm"
+)
+
+// defaultUserDetailsRefreshInterval is the default age at which we re-fetch a
+// user's profile fields from GitHub. The handoff plan (R-2) sized this at 7d:
+// long enough that the per-cycle work scales with new contributors, short
+// enough that bio / follower-count drift stays bounded.
+const defaultUserDetailsRefreshInterval = 7 * 24 * time.Hour
+
+// userDetailsRefreshInterval reads USER_DETAILS_REFRESH_INTERVAL_HOURS, or
+// returns the default. Anything <= 0 falls back to the default so a typo can't
+// silently turn the refresh into "every cycle".
+func userDetailsRefreshInterval() time.Duration {
+	if raw := os.Getenv("USER_DETAILS_REFRESH_INTERVAL_HOURS"); raw != "" {
+		if hours, err := strconv.Atoi(raw); err == nil && hours > 0 {
+			return time.Duration(hours) * time.Hour
+		}
+	}
+	return defaultUserDetailsRefreshInterval
+}
+
+// selectStaleUsers returns users whose details have never been refreshed,
+// or were last refreshed before cutoff. Login is required so we can keep
+// using the existing GraphQL `user(login:)` query without a second round-trip.
+func selectStaleUsers(db *gorm.DB, cutoff time.Time) ([]models.User, error) {
+	var users []models.User
+	err := db.
+		Where("details_synced_at IS NULL OR details_synced_at < ?", cutoff).
+		Where("login != ''").
+		Find(&users).Error
+	return users, err
+}

--- a/server/sync/user_details_test.go
+++ b/server/sync/user_details_test.go
@@ -1,0 +1,99 @@
+package sync
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/samouraiworld/topofgnomes/server/models"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func newTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := db.AutoMigrate(&models.User{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return db
+}
+
+func seedUser(t *testing.T, db *gorm.DB, login string, detailsSyncedAt time.Time) {
+	t.Helper()
+	u := models.User{ID: "u-" + login, Login: login, DetailsSyncedAt: detailsSyncedAt}
+	if err := db.Create(&u).Error; err != nil {
+		t.Fatalf("seed %s: %v", login, err)
+	}
+}
+
+func TestSelectStaleUsers_PicksNeverSyncedAndOldEntries(t *testing.T) {
+	db := newTestDB(t)
+	now := time.Date(2026, 5, 18, 0, 0, 0, 0, time.UTC)
+	cutoff := now.Add(-7 * 24 * time.Hour)
+
+	seedUser(t, db, "fresh", now.Add(-1*time.Hour))                  // skip
+	seedUser(t, db, "boundary", cutoff.Add(time.Second))             // skip — strictly newer than cutoff
+	seedUser(t, db, "stale", cutoff.Add(-time.Hour))                 // pick
+	seedUser(t, db, "never-synced", time.Time{})                     // pick
+
+	got, err := selectStaleUsers(db, cutoff)
+	if err != nil {
+		t.Fatalf("selectStaleUsers: %v", err)
+	}
+	gotLogins := map[string]bool{}
+	for _, u := range got {
+		gotLogins[u.Login] = true
+	}
+	if !gotLogins["stale"] || !gotLogins["never-synced"] {
+		t.Errorf("missing expected stale users: %v", gotLogins)
+	}
+	if gotLogins["fresh"] || gotLogins["boundary"] {
+		t.Errorf("fresh users incorrectly selected: %v", gotLogins)
+	}
+}
+
+func TestSelectStaleUsers_SkipsRowsWithoutLogin(t *testing.T) {
+	db := newTestDB(t)
+	// Some rows from syncRemaningUsers can land with a blank login if the
+	// node lookup fails. Including them in the refresh path would hammer
+	// the GraphQL endpoint with empty queries — skip them.
+	now := time.Now().UTC()
+	if err := db.Create(&models.User{ID: "u-noop", Login: ""}).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	seedUser(t, db, "real", time.Time{})
+
+	got, err := selectStaleUsers(db, now)
+	if err != nil {
+		t.Fatalf("selectStaleUsers: %v", err)
+	}
+	if len(got) != 1 || got[0].Login != "real" {
+		t.Errorf("got %+v, want only 'real'", got)
+	}
+}
+
+func TestUserDetailsRefreshInterval_DefaultsAndEnv(t *testing.T) {
+	t.Setenv("USER_DETAILS_REFRESH_INTERVAL_HOURS", "")
+	if got := userDetailsRefreshInterval(); got != defaultUserDetailsRefreshInterval {
+		t.Errorf("default = %v, want %v", got, defaultUserDetailsRefreshInterval)
+	}
+	t.Setenv("USER_DETAILS_REFRESH_INTERVAL_HOURS", "24")
+	if got := userDetailsRefreshInterval(); got != 24*time.Hour {
+		t.Errorf("env = %v, want 24h", got)
+	}
+	// Garbage and <=0 fall back to the default.
+	for _, raw := range []string{"nope", "0", "-12"} {
+		t.Run(raw, func(t *testing.T) {
+			os.Setenv("USER_DETAILS_REFRESH_INTERVAL_HOURS", raw)
+			defer os.Unsetenv("USER_DETAILS_REFRESH_INTERVAL_HOURS")
+			if got := userDetailsRefreshInterval(); got != defaultUserDetailsRefreshInterval {
+				t.Errorf("%q = %v, want default", raw, got)
+			}
+		})
+	}
+}

--- a/server/sync/workers.go
+++ b/server/sync/workers.go
@@ -1,0 +1,73 @@
+package sync
+
+import (
+	"context"
+	stdsync "sync"
+
+	"github.com/samouraiworld/topofgnomes/server/models"
+)
+
+// syncRepositoriesConcurrently fans out repository-level work across a pool
+// of workers (sized by SYNC_WORKERS, default 4). Pre-Phase-2a this loop was
+// sequential and would have started to brush GitHub's GraphQL rate limit
+// once the curated ~50-repo allowlist lands in Phase 2b (plan R-1).
+//
+// Each repo's GraphQL passes are wrapped in exponential backoff so a single
+// rate-limit hiccup doesn't drop a repo from the cycle.
+func (s *Syncer) syncRepositoriesConcurrently(ctx context.Context) {
+	workers := syncWorkerCount()
+	repoCh := make(chan models.Repository)
+	var wg stdsync.WaitGroup
+
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			for repo := range repoCh {
+				if ctx.Err() != nil {
+					return
+				}
+				s.syncOneRepo(ctx, repo, workerID)
+			}
+		}(i)
+	}
+
+	for _, r := range s.repositories {
+		select {
+		case <-ctx.Done():
+			close(repoCh)
+			wg.Wait()
+			return
+		case repoCh <- r:
+		}
+	}
+	close(repoCh)
+	wg.Wait()
+}
+
+// syncOneRepo runs the five per-repository sync passes for a single repo,
+// each wrapped in rate-limit backoff. A failure in one pass is logged but
+// doesn't skip the rest — partial progress is better than none.
+func (s *Syncer) syncOneRepo(ctx context.Context, repo models.Repository, workerID int) {
+	s.logger.Infof("[worker %d] sync starting for %s", workerID, repo.ID)
+
+	steps := []struct {
+		name string
+		fn   func() error
+	}{
+		{"users", func() error { return s.syncUsers(repo) }},
+		{"issues", func() error { return s.syncIssues(repo) }},
+		{"prs", func() error { return s.syncPRs(repo) }},
+		{"milestones", func() error { return s.syncMilestones(repo) }},
+		{"commits", func() error { return s.syncCommits(repo) }},
+	}
+	for _, step := range steps {
+		if ctx.Err() != nil {
+			return
+		}
+		err := backoffRetry(ctx, defaultBackoffAttempts, defaultBackoffBase, isRateLimitErr, step.fn)
+		if err != nil {
+			s.logger.Errorf("[worker %d] %s sync %s failed: %v", workerID, repo.ID, step.name, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Phase 2a of the gnolove team-hub rework. Three logical commits, 17 new unit tests, all `go test ./...` green. Lands ahead of the Phase 2b curated ~50-repo expansion so the sync layer can absorb it without brushing GitHub rate limits or silently degrading the leaderboard.

Independent of PR #220 — touches `models/repository.go`, `models/user.go`, and the `sync/` package only. Either PR can merge first.

### What ships

**1. Harden `GITHUB_REPOSITORIES` parser** (commit 1)
- Accept commas, spaces, newlines, and tabs as separators (mix-and-match).
- Trim entries; skip blanks instead of silently creating `Repository{}` rows.
- Error messages include 1-based entry index + offending string so a bad deploy is grep-able from the server log.
- Reject empty config and empty owner/name/branch components up-front.

**2. Incremental `syncUserDetails`** (commit 2) — mitigates plan R-2
- Adds indexed `users.details_synced_at` column.
- Each cycle only re-fetches users whose stamp is older than `USER_DETAILS_REFRESH_INTERVAL_HOURS` (default 168 = 7d), or null.
- Stamp set only on the happy path — transient GraphQL errors keep the user "stale" for next cycle.
- Garbage env values fall back to default (fail-closed).

**3. Sharded sync workers + rate-limit backoff** (commit 3) — mitigates plan R-1
- Repository sync fans out across N workers (`SYNC_WORKERS` env, default 4, clamped `[1,16]`).
- Each repo's five GraphQL passes wrap in exponential backoff (2s → 4s → 8s → 16s, max 4 attempts) on rate-limit-shaped errors. Non-retryable errors fail fast.
- A failure in one pass logs and continues, so partial progress wins over none.

### Test plan

- [x] `go test ./...` — 17 new unit tests covering: parser separators, error messages, error positions, empty/invalid component rejection; stale-user selector (cutoff boundaries, blank-login skip); worker count clamping; rate-limit detector pattern matches; backoff happy path / non-retryable / exhaustion / ctx-cancellation.
- [x] `go build ./...` clean.
- [ ] **Operator:** approve / request changes.
- [ ] **Lours:** deploy. Optional `SYNC_WORKERS` and `USER_DETAILS_REFRESH_INTERVAL_HOURS` env vars — both have safe defaults.
- [ ] **Production smoke (post-deploy):** confirm the cycle log line `User details sync: refreshing N stale users (cutoff=...)` shows up; verify multi-worker fan-out by grepping `[worker 0]`, `[worker 1]`, etc.

### Rollback

All changes are additive. `details_synced_at` defaults to zero so a rolled-back binary just refreshes everything next cycle (back to current behaviour). Worker count of 1 (`SYNC_WORKERS=1`) restores sequential behaviour without a redeploy.

### Out of scope

- N=4 sqlite contention benchmark (plan deliverable) — defer until post-deploy with real GitHub traffic, since synthetic load tells us less than the real distribution. If `SQLITE_BUSY` errors show up in the server log within 24h of deploy, drop to `SYNC_WORKERS=2`.
- Phase 2b curated ~50-repo expansion — separate Ansible PR per plan §4.