### PR TITLE
feat(topics): server-side Focus Areas taxonomy + GET /topics (Phase 2c step 1)

### DIFF
--- a/server/config/topics.yaml
+++ b/server/config/topics.yaml
@@ -1,0 +1,147 @@
+# gnolove Focus Areas taxonomy — single source of truth for /topics.
+#
+# Editing rules
+# - schemaVersion bumps when the YAML shape changes (not when topics change).
+# - slug is lowercase kebab-case, unique case-insensitively.
+# - label is the user-visible string. Unique case-insensitively.
+# - patterns are RE2 source strings. Matching is performed against a
+#   lowercased haystack of `${repo_name} ${pr_title}`, so do NOT include
+#   case-folded patterns — write everything lowercase and the matcher
+#   handles case folding at the boundary.
+# - Order matters: earlier rules win on ambiguous hits. The first rule
+#   that matches wins, exactly like the legacy frontend logic. Tune
+#   order so the highest-signal topic wins when multiple match.
+# - The "other" bucket is NOT defined here. It's the classifier's
+#   default fallback when no rule matches.
+#
+# After editing, run `go test ./topics/...` then bounce the gnolove backend.
+
+schemaVersion: 1
+
+topics:
+  - slug: gnovm
+    label: Gno VM
+    patterns:
+      - '\bvm\b'
+      - 'interpreter'
+      - '\bstack[- ]engine\b'
+      - 'gnoland/gno'
+
+  - slug: gnocore
+    label: Core protocol
+    patterns:
+      - '\bcore\b'
+      - '\bprotocol\b'
+      - 'tm2'
+      - 'consensus'
+
+  - slug: gnosdk
+    label: SDK
+    patterns:
+      - '\bsdk\b'
+      - '\bjs-client\b'
+      - 'tx[- ]builder'
+
+  - slug: gnops
+    label: Ops & infra
+    patterns:
+      - 'portal[- ]loop'
+      - 'validator'
+      - '\binfra\b'
+      - 'deploy'
+      - '\bops\b'
+
+  - slug: security
+    label: Security
+    patterns:
+      - '\bsecurity\b'
+      - '\bauth\b'
+      - 'audit'
+      - 'multisig'
+      - 'signer'
+      - 'cve'
+
+  - slug: devx
+    label: DevX & tooling
+    patterns:
+      - 'gnopls'
+      - 'gno-?cli'
+      - 'devx'
+      - '\btooling\b'
+      - '\blinter\b'
+      - '\blsp\b'
+
+  - slug: docs
+    label: Docs
+    patterns:
+      - '\bdocs?\b'
+      - 'readme'
+      - 'tutorial'
+
+  - slug: wallet
+    label: Wallet
+    patterns:
+      - 'adena'
+      - '\bwallet\b'
+      - 'gnokey'
+
+  - slug: indexer
+    label: Indexer & API
+    patterns:
+      - 'gnoscan'
+      - '\bindexer\b'
+      - '\bgraphql\b'
+
+  - slug: governance
+    label: Governance
+    patterns:
+      - 'govdao'
+      - '\bgovern'
+      - '\bproposal'
+      - 'multisig'
+
+  - slug: dex
+    label: DEX
+    patterns:
+      - 'gnoswap'
+      - '\bdex\b'
+      - '\bswap\b'
+      - '\bamm\b'
+      - 'liquidity'
+
+  - slug: nft
+    label: NFT
+    patterns:
+      - '\bnft\b'
+      - '\berc721\b'
+      - 'grc721'
+
+  - slug: messaging
+    label: Messaging
+    patterns:
+      - 'berty'
+      - 'messaging'
+      - '\bp2p\b'
+
+  - slug: ibc
+    label: IBC
+    patterns:
+      - '\bibc\b'
+      - 'cosmos[- ]sdk'
+      - 'relayer'
+
+  - slug: ai
+    label: AI
+    patterns:
+      - '\bai\b'
+      - 'mistral'
+      - 'openrouter'
+      - '\bllm\b'
+
+  - slug: zk
+    label: ZK
+    patterns:
+      - '\bzk\b'
+      - 'zero[- ]knowledge'
+      - '\bsnark\b'
+      - '\bstark\b'

--- a/server/handler/topics/topics.go
+++ b/server/handler/topics/topics.go
@@ -1,0 +1,30 @@
+// Package topics wires the /topics endpoint that exposes the Focus Areas
+// taxonomy (gnolove/server/config/topics.yaml) to the Memba frontend.
+package topics
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/samouraiworld/topofgnomes/server/topics"
+)
+
+type topicsResponse struct {
+	SchemaVersion int            `json:"schemaVersion"`
+	LastSyncedAt  time.Time      `json:"lastSyncedAt"`
+	Topics        []topics.Topic `json:"topics"`
+}
+
+// HandleGetAll serves the full topic taxonomy with the file mtime so the
+// frontend can bust its query cache when ops re-deploys the YAML.
+func HandleGetAll(cfg *topics.Config) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(topicsResponse{
+			SchemaVersion: cfg.SchemaVersion,
+			LastSyncedAt:  cfg.LastSyncedAt,
+			Topics:        cfg.Topics,
+		})
+	}
+}

--- a/server/handler/topics/topics_test.go
+++ b/server/handler/topics/topics_test.go
@@ -1,0 +1,91 @@
+package topics
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/samouraiworld/topofgnomes/server/topics"
+)
+
+func fixtureConfig(t *testing.T) *topics.Config {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "topics.yaml")
+	body := `
+schemaVersion: 1
+topics:
+  - {slug: wallet,  label: Wallet,        patterns: ['adena', '\bwallet\b']}
+  - {slug: indexer, label: Indexer & API, patterns: ['gnoscan', '\bindexer\b']}
+`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	cfg, err := topics.Load(path)
+	if err != nil {
+		t.Fatalf("load fixture: %v", err)
+	}
+	return cfg
+}
+
+func TestHandleGetAll_ReturnsTopicsWithSchemaAndSyncedAt(t *testing.T) {
+	cfg := fixtureConfig(t)
+	h := HandleGetAll(cfg)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/topics", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var body struct {
+		SchemaVersion int            `json:"schemaVersion"`
+		LastSyncedAt  time.Time      `json:"lastSyncedAt"`
+		Topics        []topics.Topic `json:"topics"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body.SchemaVersion != 1 {
+		t.Errorf("schemaVersion = %d, want 1", body.SchemaVersion)
+	}
+	if body.LastSyncedAt.IsZero() {
+		t.Error("lastSyncedAt missing")
+	}
+	if len(body.Topics) != 2 {
+		t.Fatalf("topics len = %d, want 2", len(body.Topics))
+	}
+	if body.Topics[0].Slug != "wallet" {
+		t.Errorf("topics[0].slug = %q, want wallet", body.Topics[0].Slug)
+	}
+	if len(body.Topics[0].Patterns) != 2 {
+		t.Errorf("topics[0].patterns len = %d, want 2", len(body.Topics[0].Patterns))
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", got)
+	}
+}
+
+func TestHandleGetAll_PreservesYAMLOrder(t *testing.T) {
+	// Order matters for first-match-wins classification on the frontend.
+	cfg := fixtureConfig(t)
+	h := HandleGetAll(cfg)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/topics", nil))
+
+	var body struct {
+		Topics []topics.Topic `json:"topics"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body.Topics[0].Slug != "wallet" || body.Topics[1].Slug != "indexer" {
+		t.Errorf("order = [%s, %s], want [wallet, indexer]",
+			body.Topics[0].Slug, body.Topics[1].Slug)
+	}
+}

--- a/server/main.go
+++ b/server/main.go
@@ -21,11 +21,13 @@ import (
 	"github.com/samouraiworld/topofgnomes/server/handler/ai"
 	"github.com/samouraiworld/topofgnomes/server/handler/contributor"
 	teamshandler "github.com/samouraiworld/topofgnomes/server/handler/teams"
+	topicshandler "github.com/samouraiworld/topofgnomes/server/handler/topics"
 	infrarepo "github.com/samouraiworld/topofgnomes/server/infra/repository"
 	"github.com/samouraiworld/topofgnomes/server/models"
 	"github.com/samouraiworld/topofgnomes/server/signer"
 	"github.com/samouraiworld/topofgnomes/server/sync"
 	"github.com/samouraiworld/topofgnomes/server/teams"
+	"github.com/samouraiworld/topofgnomes/server/topics"
 	"github.com/subosito/gotenv"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
@@ -73,6 +75,16 @@ func main() {
 		panic(fmt.Errorf("load teams config: %w", err))
 	}
 	logger.Infof("loaded %d teams from %s (mtime=%s)", len(teamsCfg.Teams), teamsConfigPath, teamsCfg.LastSyncedAt.Format(time.RFC3339))
+
+	topicsConfigPath := os.Getenv("TOPICS_CONFIG_PATH")
+	if topicsConfigPath == "" {
+		topicsConfigPath = "config/topics.yaml"
+	}
+	topicsCfg, err := topics.Load(topicsConfigPath)
+	if err != nil {
+		panic(fmt.Errorf("load topics config: %w", err))
+	}
+	logger.Infof("loaded %d topics from %s (mtime=%s)", len(topicsCfg.Topics), topicsConfigPath, topicsCfg.LastSyncedAt.Format(time.RFC3339))
 
 	database, err = db.InitDB()
 	if err != nil {
@@ -171,6 +183,8 @@ func main() {
 	router.Get("/teams/{slug}", teamshandler.HandleGetBySlug(teamsCfg))
 	router.Get("/teams/{slug}/active-repos", teamshandler.HandleGetActiveRepos(database, teamsCfg, cache))
 	router.Get("/teams/{slug}/team-stats", teamshandler.HandleGetTeamStats(database, teamsCfg, cache))
+
+	router.Get("/topics", topicshandler.HandleGetAll(topicsCfg))
 
 	router.HandleFunc("/repositories", handler.HandleGetRepository(database))
 	router.HandleFunc("/stats", handler.HandleGetUserStats(database, cache))

--- a/server/topics/topics.go
+++ b/server/topics/topics.go
@@ -1,0 +1,159 @@
+// Package topics loads and validates the gnolove Focus Areas taxonomy from a
+// YAML config file. The taxonomy is the source of truth for which PR/repo
+// patterns map to which topic slug and powers the /topics endpoint plus the
+// server-side classifier used by AI prompts in future phases.
+//
+// Frontend mirror: Memba/frontend/src/lib/gnoloveFocusAreas.ts (Phase 2c
+// switches it from a hardcoded copy to a seed-union over GET /topics).
+package topics
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// SchemaVersion is the YAML shape this loader understands.
+const SchemaVersion = 1
+
+// OtherSlug is the fallback bucket the classifier returns when no rule
+// matches. It's reserved at the YAML level — config cannot declare a topic
+// with this slug — because consumers treat it as a special case (hidden
+// unless it represents > 5% of the team's signal).
+const OtherSlug = "other"
+
+type Topic struct {
+	Slug     string   `yaml:"slug"     json:"slug"`
+	Label    string   `yaml:"label"    json:"label"`
+	Patterns []string `yaml:"patterns" json:"patterns"`
+}
+
+// Config is the parsed topics.yaml plus compiled regexes and the file mtime
+// (surfaced to the frontend as `lastSyncedAt` so the cache key in
+// `useGnoloveTopics` bumps when ops re-deploys the taxonomy).
+type Config struct {
+	SchemaVersion int       `yaml:"schemaVersion" json:"schemaVersion"`
+	Topics        []Topic   `yaml:"topics"        json:"topics"`
+	LastSyncedAt  time.Time `yaml:"-"             json:"lastSyncedAt"`
+
+	// compiled[i] is the regex set for Topics[i], in declaration order.
+	// Kept off the wire — clients receive raw pattern strings and compile
+	// them in JS (or use them as-is in their own classifier).
+	compiled [][]*regexp.Regexp
+}
+
+func Load(path string) (*Config, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("stat %s: %w", path, err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var cfg Config
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if cfg.SchemaVersion != SchemaVersion {
+		return nil, fmt.Errorf("schemaVersion = %d, want %d", cfg.SchemaVersion, SchemaVersion)
+	}
+	compiled, err := validate(cfg.Topics)
+	if err != nil {
+		return nil, err
+	}
+	cfg.compiled = compiled
+	cfg.LastSyncedAt = info.ModTime().UTC()
+	return &cfg, nil
+}
+
+// FindBySlug returns the topic for the given slug (case-insensitive).
+func (c *Config) FindBySlug(slug string) (Topic, bool) {
+	want := strings.ToLower(slug)
+	for _, t := range c.Topics {
+		if strings.ToLower(t.Slug) == want {
+			return t, true
+		}
+	}
+	return Topic{}, false
+}
+
+// Classify returns the slug of the first matching topic for the given
+// `(repo, title)` pair, or [OtherSlug] when none match. Matching is done
+// against a lowercased `${repo} ${title}` haystack — keep YAML patterns
+// lowercase (or case-fold via `(?i)`) accordingly.
+func (c *Config) Classify(repo, title string) string {
+	haystack := strings.ToLower(repo + " " + title)
+	for i, t := range c.Topics {
+		for _, re := range c.compiled[i] {
+			if re.MatchString(haystack) {
+				return t.Slug
+			}
+		}
+	}
+	return OtherSlug
+}
+
+func validate(topics []Topic) ([][]*regexp.Regexp, error) {
+	if len(topics) == 0 {
+		return nil, fmt.Errorf("topics: empty taxonomy")
+	}
+	seenSlug := map[string]string{}  // lower -> original
+	seenLabel := map[string]string{} // lower -> original
+	compiled := make([][]*regexp.Regexp, len(topics))
+	for i, t := range topics {
+		if err := checkWhitespace("slug", t.Slug); err != nil {
+			return nil, err
+		}
+		if err := checkWhitespace("label", t.Label); err != nil {
+			return nil, err
+		}
+		if t.Slug == "" {
+			return nil, fmt.Errorf("topic has empty slug")
+		}
+		if t.Label == "" {
+			return nil, fmt.Errorf("topic %q: empty label", t.Slug)
+		}
+		if strings.EqualFold(t.Slug, OtherSlug) {
+			return nil, fmt.Errorf("topic %q: slug %q is reserved for the unmatched bucket", t.Slug, OtherSlug)
+		}
+		slugKey := strings.ToLower(t.Slug)
+		if prev, ok := seenSlug[slugKey]; ok {
+			return nil, fmt.Errorf("duplicate slug %q (also seen as %q)", t.Slug, prev)
+		}
+		seenSlug[slugKey] = t.Slug
+
+		labelKey := strings.ToLower(t.Label)
+		if prev, ok := seenLabel[labelKey]; ok {
+			return nil, fmt.Errorf("duplicate label %q (also seen as %q)", t.Label, prev)
+		}
+		seenLabel[labelKey] = t.Label
+
+		if len(t.Patterns) == 0 {
+			return nil, fmt.Errorf("topic %q: patterns must be non-empty", t.Slug)
+		}
+		compiled[i] = make([]*regexp.Regexp, len(t.Patterns))
+		for j, p := range t.Patterns {
+			if p == "" {
+				return nil, fmt.Errorf("topic %q: empty pattern at index %d", t.Slug, j)
+			}
+			re, err := regexp.Compile(p)
+			if err != nil {
+				return nil, fmt.Errorf("topic %q: invalid regex %q: %w", t.Slug, p, err)
+			}
+			compiled[i][j] = re
+		}
+	}
+	return compiled, nil
+}
+
+func checkWhitespace(field, val string) error {
+	if val != strings.TrimSpace(val) {
+		return fmt.Errorf("%s %q has leading/trailing whitespace", field, val)
+	}
+	return nil
+}

--- a/server/topics/topics_test.go
+++ b/server/topics/topics_test.go
@@ -1,0 +1,242 @@
+package topics
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeYAML(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "topics.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+	return path
+}
+
+const validYAML = `
+schemaVersion: 1
+topics:
+  - slug: wallet
+    label: Wallet
+    patterns: ['adena', '\bwallet\b']
+  - slug: indexer
+    label: Indexer & API
+    patterns: ['gnoscan', '\bindexer\b']
+`
+
+func TestLoadValidYAML(t *testing.T) {
+	cfg, err := Load(writeYAML(t, validYAML))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.SchemaVersion != 1 {
+		t.Fatalf("schemaVersion = %d, want 1", cfg.SchemaVersion)
+	}
+	if len(cfg.Topics) != 2 {
+		t.Fatalf("topics = %d, want 2", len(cfg.Topics))
+	}
+	if cfg.LastSyncedAt.IsZero() {
+		t.Fatal("LastSyncedAt must be the file mtime, got zero")
+	}
+	if cfg.Topics[0].Slug != "wallet" {
+		t.Fatalf("first topic slug = %q, want wallet", cfg.Topics[0].Slug)
+	}
+}
+
+func TestRejectWrongSchemaVersion(t *testing.T) {
+	yaml := `
+schemaVersion: 99
+topics:
+  - {slug: wallet, label: Wallet, patterns: ['x']}
+`
+	_, err := Load(writeYAML(t, yaml))
+	if err == nil || !strings.Contains(err.Error(), "schemaVersion") {
+		t.Fatalf("want schemaVersion error, got %v", err)
+	}
+}
+
+func TestRejectEmptyTopics(t *testing.T) {
+	yaml := `
+schemaVersion: 1
+topics: []
+`
+	_, err := Load(writeYAML(t, yaml))
+	if err == nil || !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("want empty-topics error, got %v", err)
+	}
+}
+
+func TestRejectDuplicateSlugCaseInsensitive(t *testing.T) {
+	yaml := `
+schemaVersion: 1
+topics:
+  - {slug: Wallet, label: A, patterns: ['x']}
+  - {slug: wallet, label: B, patterns: ['y']}
+`
+	_, err := Load(writeYAML(t, yaml))
+	if err == nil || !strings.Contains(err.Error(), "duplicate slug") {
+		t.Fatalf("want duplicate-slug error, got %v", err)
+	}
+}
+
+func TestRejectDuplicateLabelCaseInsensitive(t *testing.T) {
+	yaml := `
+schemaVersion: 1
+topics:
+  - {slug: a, label: Wallet, patterns: ['x']}
+  - {slug: b, label: wallet, patterns: ['y']}
+`
+	_, err := Load(writeYAML(t, yaml))
+	if err == nil || !strings.Contains(err.Error(), "duplicate label") {
+		t.Fatalf("want duplicate-label error, got %v", err)
+	}
+}
+
+func TestRejectReservedOtherSlug(t *testing.T) {
+	yaml := `
+schemaVersion: 1
+topics:
+  - {slug: other, label: Other, patterns: ['x']}
+`
+	_, err := Load(writeYAML(t, yaml))
+	if err == nil || !strings.Contains(err.Error(), "reserved") {
+		t.Fatalf("want reserved-slug error, got %v", err)
+	}
+}
+
+func TestRejectInvalidRegex(t *testing.T) {
+	yaml := `
+schemaVersion: 1
+topics:
+  - {slug: a, label: A, patterns: ['[unclosed']}
+`
+	_, err := Load(writeYAML(t, yaml))
+	if err == nil || !strings.Contains(err.Error(), "regex") {
+		t.Fatalf("want invalid-regex error, got %v", err)
+	}
+}
+
+func TestRejectEmptyPatterns(t *testing.T) {
+	yaml := `
+schemaVersion: 1
+topics:
+  - {slug: a, label: A, patterns: []}
+`
+	_, err := Load(writeYAML(t, yaml))
+	if err == nil || !strings.Contains(err.Error(), "patterns") {
+		t.Fatalf("want empty-patterns error, got %v", err)
+	}
+}
+
+func TestRejectWhitespaceInSlug(t *testing.T) {
+	yaml := `
+schemaVersion: 1
+topics:
+  - {slug: " wallet ", label: Wallet, patterns: ['x']}
+`
+	_, err := Load(writeYAML(t, yaml))
+	if err == nil || !strings.Contains(err.Error(), "whitespace") {
+		t.Fatalf("want whitespace error, got %v", err)
+	}
+}
+
+func TestFindBySlugIsCaseInsensitive(t *testing.T) {
+	cfg, err := Load(writeYAML(t, validYAML))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	tp, ok := cfg.FindBySlug("WALLET")
+	if !ok {
+		t.Fatal("FindBySlug must match case-insensitively")
+	}
+	if tp.Slug != "wallet" {
+		t.Fatalf("got slug %q, want wallet", tp.Slug)
+	}
+	if _, ok := cfg.FindBySlug("missing"); ok {
+		t.Fatal("FindBySlug should miss for unknown slug")
+	}
+}
+
+func TestClassifyMatchesByRepoName(t *testing.T) {
+	cfg, err := Load(writeYAML(t, validYAML))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got := cfg.Classify("onbloc/adena-wallet", "any title")
+	if got != "wallet" {
+		t.Errorf("Classify(adena-wallet) = %q, want wallet", got)
+	}
+}
+
+func TestClassifyMatchesByTitle(t *testing.T) {
+	cfg, err := Load(writeYAML(t, validYAML))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got := cfg.Classify("some/repo", "fix: indexer race")
+	if got != "indexer" {
+		t.Errorf("Classify(title=indexer) = %q, want indexer", got)
+	}
+}
+
+func TestClassifyIsCaseInsensitive(t *testing.T) {
+	cfg, err := Load(writeYAML(t, validYAML))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got := cfg.Classify("Onbloc/Adena-Wallet", "X")
+	if got != "wallet" {
+		t.Errorf("Classify mixed-case = %q, want wallet", got)
+	}
+}
+
+func TestClassifyFirstMatchWins(t *testing.T) {
+	// wallet rule comes before indexer; a hit on both wins for wallet.
+	cfg, err := Load(writeYAML(t, validYAML))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got := cfg.Classify("onbloc/adena-wallet", "feat: indexer rewrite")
+	if got != "wallet" {
+		t.Errorf("Classify first-match = %q, want wallet", got)
+	}
+}
+
+func TestClassifyFallsThroughToOther(t *testing.T) {
+	cfg, err := Load(writeYAML(t, validYAML))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got := cfg.Classify("weirdorg/totallynew", "feat: random")
+	if got != OtherSlug {
+		t.Errorf("Classify unmatched = %q, want %q", got, OtherSlug)
+	}
+}
+
+func TestLoadRealConfigFile(t *testing.T) {
+	// Smoke test the actual checked-in config so a bad commit fails CI.
+	cfg, err := Load("../config/topics.yaml")
+	if err != nil {
+		t.Fatalf("real topics.yaml: %v", err)
+	}
+	if len(cfg.Topics) < 10 {
+		t.Fatalf("expected real config to have >=10 topics, got %d", len(cfg.Topics))
+	}
+	// Parity smoke: the gnolove/gno repo should classify as gnovm
+	// (it's the canonical first-rule-wins case from the legacy TS).
+	if got := cfg.Classify("gnoland/gno", "feat: core consensus tweak"); got != "gnovm" {
+		t.Errorf("gnoland/gno + core title => %q, want gnovm", got)
+	}
+	// adena-wallet should pick wallet, not security (auth pattern).
+	if got := cfg.Classify("onbloc/adena-wallet", "x"); got != "wallet" {
+		t.Errorf("adena-wallet => %q, want wallet", got)
+	}
+	// gnoscan should pick indexer, not other.
+	if got := cfg.Classify("onbloc/gnoscan", "x"); got != "indexer" {
+		t.Errorf("gnoscan => %q, want indexer", got)
+	}
+}


### PR DESCRIPTION
## Summary

Moves the Focus Areas regex bag — currently hardcoded inside Memba's `gnoloveFocusAreas.ts` — to a YAML config the gnolove backend serves. This stops the Memba copy from drifting from anything else that wants to reuse the taxonomy (AI prompts, future analytics matrix).

- `server/config/topics.yaml` — 16 topics ported verbatim from the legacy TS rules. "other" is the unmatched-bucket sentinel and is reserved at the YAML level.
- `server/topics` — Load + validate + Classify (first-match-wins on a lowercased `${repo} ${title}` haystack, exactly the contract the TS used). 17 unit tests including a smoke test against the real checked-in YAML so a bad commit fails CI.
- `server/handler/topics` — `GET /topics` emits `{schemaVersion, lastSyncedAt, topics:[{slug, label, patterns:[]}]}`. Raw RE2 source strings on the wire — clients recompile.
- `main.go` — `TOPICS_CONFIG_PATH` env (default `config/topics.yaml`).

Memba consumer ships as a separate PR (samouraiworld/memba). This one must merge + deploy first.

## Test plan

- [x] `go test ./topics/... ./handler/topics/...` green
- [x] `go test ./...` for the whole server green
- [x] `go build ./...` clean
- [x] Real YAML smoke test parses + classifies `gnoland/gno` → `gnovm`, `adena-wallet` → `wallet`, `gnoscan` → `indexer` (locked into `TestLoadRealConfigFile`)
- [ ] After merge: Lours deploys; one curl to `https://<gnolove-host>/topics` returns 200 with `schemaVersion: 1` and the 16-topic array

## Notes for Lours

- Dockerfile uses `COPY . .` so `server/config/topics.yaml` is packaged automatically. No env work required.
- No DB migrations.