### PR TITLE
feat(analytics): /contributors/cohorts + /team-collab endpoints

### DIFF
--- a/server/handler/contributor/cohorts.go
+++ b/server/handler/contributor/cohorts.go
@@ -1,0 +1,188 @@
+package contributor
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/dgraph-io/ristretto"
+	"github.com/samouraiworld/topofgnomes/server/models"
+	"gorm.io/gorm"
+)
+
+const (
+	cohortsCacheKey  = "contributors:cohorts:v1"
+	cohortsCacheTTL  = 5 * time.Minute
+	cohortsSchemaVer = 1
+	// Cap the cohort window so the response stays bounded and the chart
+	// stays legible. Cohorts older than this still count as "cohort 0"
+	// in the global activity rollup but don't get their own row.
+	cohortsLookbackMonths = 24
+)
+
+// CohortRow is one cohort's retention curve.
+type CohortRow struct {
+	// Month in `YYYY-MM` form — the month of each user's FIRST observed PR.
+	Month string `json:"month"`
+	// Number of distinct users whose first PR was in this month.
+	Size int `json:"size"`
+	// Fraction of the cohort that contributed (any PR) in each subsequent
+	// month-offset. Index 0 = the cohort month itself (always 1.0).
+	// Length grows up to the trailing month or `cohortsLookbackMonths`,
+	// whichever is shorter.
+	Retention []float64 `json:"retention"`
+}
+
+type cohortsResponse struct {
+	SchemaVersion int         `json:"schemaVersion"`
+	LastSyncedAt  *time.Time  `json:"lastSyncedAt"`
+	GeneratedAt   time.Time   `json:"generatedAt"`
+	Cohorts       []CohortRow `json:"cohorts"`
+}
+
+// HandleGetCohorts returns the retention curve for each monthly cohort of
+// contributors, derived from the PR record. Cohort = month of a user's
+// first observed PR. Retention point N = fraction of the cohort that had
+// at least one PR in the Nth month after cohort.
+//
+// Plan §2 "contributor-cohort retention curve" lives in /gnolove/analytics.
+// Cached 5 min via ristretto; no path params.
+func HandleGetCohorts(db *gorm.DB, cache *ristretto.Cache) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if cache != nil {
+			if cached, ok := cache.Get(cohortsCacheKey); ok {
+				_ = json.NewEncoder(w).Encode(cached.(cohortsResponse))
+				return
+			}
+		}
+		rows, lastSyncedAt, err := computeCohorts(db, time.Now().UTC(), cohortsLookbackMonths)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		resp := cohortsResponse{
+			SchemaVersion: cohortsSchemaVer,
+			LastSyncedAt:  lastSyncedAt,
+			GeneratedAt:   time.Now().UTC(),
+			Cohorts:       rows,
+		}
+		if cache != nil {
+			cache.SetWithTTL(cohortsCacheKey, resp, 0, cohortsCacheTTL)
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}
+}
+
+// computeCohorts is the pure computation, factored out for tests.
+//
+// `now` pins the trailing-window edge so unit tests are reproducible.
+// `lookback` caps how many cohort months get a row in the output (older
+// cohorts are still folded into the global stats but not surfaced).
+func computeCohorts(db *gorm.DB, now time.Time, lookback int) ([]CohortRow, *time.Time, error) {
+	if db == nil {
+		return nil, nil, fmt.Errorf("db is nil")
+	}
+
+	type prRow struct {
+		AuthorID  string    `gorm:"column:author_id"`
+		CreatedAt time.Time `gorm:"column:created_at"`
+	}
+	var prs []prRow
+	if err := db.Model(&models.PullRequest{}).
+		Select("author_id, created_at").
+		Where("created_at IS NOT NULL AND author_id <> ''").
+		Order("created_at ASC").
+		Scan(&prs).Error; err != nil {
+		return nil, nil, fmt.Errorf("cohorts: scan PRs: %w", err)
+	}
+
+	// Per-author first PR month (the cohort).
+	firstMonth := make(map[string]string, len(prs))
+	for _, p := range prs {
+		month := p.CreatedAt.UTC().Format("2006-01")
+		if _, seen := firstMonth[p.AuthorID]; !seen {
+			firstMonth[p.AuthorID] = month
+		}
+	}
+
+	// (cohort_month, month_offset) -> set of distinct author IDs active.
+	active := map[string]map[int]map[string]struct{}{}
+	cohortMembers := map[string]map[string]struct{}{}
+
+	for _, p := range prs {
+		cohort := firstMonth[p.AuthorID]
+		month := p.CreatedAt.UTC().Format("2006-01")
+		offset := monthDiff(cohort, month)
+		if offset < 0 {
+			continue
+		}
+		if cohortMembers[cohort] == nil {
+			cohortMembers[cohort] = map[string]struct{}{}
+		}
+		cohortMembers[cohort][p.AuthorID] = struct{}{}
+		if active[cohort] == nil {
+			active[cohort] = map[int]map[string]struct{}{}
+		}
+		if active[cohort][offset] == nil {
+			active[cohort][offset] = map[string]struct{}{}
+		}
+		active[cohort][offset][p.AuthorID] = struct{}{}
+	}
+
+	// Only emit cohorts within the lookback window so the chart stays legible.
+	earliestCohort := now.AddDate(0, -lookback, 0).Format("2006-01")
+	nowMonth := now.Format("2006-01")
+
+	cohortMonths := make([]string, 0, len(cohortMembers))
+	for c := range cohortMembers {
+		if c >= earliestCohort {
+			cohortMonths = append(cohortMonths, c)
+		}
+	}
+	sort.Strings(cohortMonths)
+
+	rows := make([]CohortRow, 0, len(cohortMonths))
+	for _, c := range cohortMonths {
+		size := len(cohortMembers[c])
+		if size == 0 {
+			continue
+		}
+		maxOffset := monthDiff(c, nowMonth)
+		retention := make([]float64, 0, maxOffset+1)
+		for offset := 0; offset <= maxOffset; offset++ {
+			count := 0
+			if bucket, ok := active[c][offset]; ok {
+				count = len(bucket)
+			}
+			retention = append(retention, float64(count)/float64(size))
+		}
+		rows = append(rows, CohortRow{Month: c, Size: size, Retention: retention})
+	}
+
+	// LastSyncedAt from the global sync_status row, mirroring stats.go.
+	var lastSyncedAt *time.Time
+	var status models.SyncStatus
+	if err := db.First(&status, 1).Error; err == nil && !status.LastSyncedAt.IsZero() {
+		ts := status.LastSyncedAt.UTC()
+		lastSyncedAt = &ts
+	}
+
+	return rows, lastSyncedAt, nil
+}
+
+// monthDiff returns (b.year*12+b.month) - (a.year*12+a.month) given two
+// `YYYY-MM` strings. Returns 0 on parse failure to avoid silent skews.
+func monthDiff(aMonth, bMonth string) int {
+	a, err := time.Parse("2006-01", aMonth)
+	if err != nil {
+		return 0
+	}
+	b, err := time.Parse("2006-01", bMonth)
+	if err != nil {
+		return 0
+	}
+	return (b.Year()-a.Year())*12 + int(b.Month()-a.Month())
+}

--- a/server/handler/contributor/cohorts_test.go
+++ b/server/handler/contributor/cohorts_test.go
@@ -1,0 +1,181 @@
+package contributor
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/dgraph-io/ristretto"
+	"github.com/samouraiworld/topofgnomes/server/models"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func newTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&models.User{}, &models.PullRequest{}, &models.SyncStatus{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return db
+}
+
+func seedPR(t *testing.T, db *gorm.DB, prID, authorID string, createdAt time.Time) {
+	t.Helper()
+	pr := models.PullRequest{
+		ID:        prID,
+		AuthorID:  authorID,
+		CreatedAt: createdAt,
+		State:     "MERGED",
+	}
+	if err := db.Create(&pr).Error; err != nil {
+		t.Fatalf("seed pr: %v", err)
+	}
+}
+
+func TestMonthDiff(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"2026-01", "2026-01", 0},
+		{"2026-01", "2026-02", 1},
+		{"2026-01", "2027-01", 12},
+		{"2025-12", "2026-01", 1},
+		{"2026-03", "2026-01", -2},
+	}
+	for _, c := range cases {
+		if got := monthDiff(c.a, c.b); got != c.want {
+			t.Errorf("monthDiff(%q,%q) = %d, want %d", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+func TestComputeCohorts_Basics(t *testing.T) {
+	db := newTestDB(t)
+	mk := func(s string) time.Time {
+		ts, err := time.Parse("2006-01-02", s)
+		if err != nil {
+			t.Fatalf("parse %q: %v", s, err)
+		}
+		return ts.UTC()
+	}
+
+	// alice: first PR 2026-01, then active 2026-02 + 2026-03
+	for i, d := range []string{"2026-01-15", "2026-02-10", "2026-03-05"} {
+		seedPR(t, db, fmt.Sprintf("alice-%d", i), "alice", mk(d))
+	}
+	// bob: first PR 2026-01 — cohort partner. Active only 2026-01.
+	seedPR(t, db, "bob-0", "bob", mk("2026-01-20"))
+	// carol: first PR 2026-02 — new cohort. Active 2026-02 + 2026-03.
+	seedPR(t, db, "carol-0", "carol", mk("2026-02-12"))
+	seedPR(t, db, "carol-1", "carol", mk("2026-03-19"))
+
+	rows, _, err := computeCohorts(db, mk("2026-03-31"), 24)
+	if err != nil {
+		t.Fatalf("computeCohorts: %v", err)
+	}
+	byMonth := map[string]CohortRow{}
+	for _, r := range rows {
+		byMonth[r.Month] = r
+	}
+
+	jan := byMonth["2026-01"]
+	if jan.Size != 2 {
+		t.Errorf("Jan cohort size = %d, want 2 (alice + bob)", jan.Size)
+	}
+	if len(jan.Retention) != 3 {
+		t.Fatalf("Jan retention len = %d, want 3 (Jan, Feb, Mar)", len(jan.Retention))
+	}
+	if jan.Retention[0] != 1.0 {
+		t.Errorf("Jan retention[0] = %v, want 1.0", jan.Retention[0])
+	}
+	// Feb activity for Jan cohort: alice contributed → 1/2 = 0.5
+	if jan.Retention[1] != 0.5 {
+		t.Errorf("Jan retention[1] = %v, want 0.5", jan.Retention[1])
+	}
+	// Mar activity for Jan cohort: alice only → 0.5
+	if jan.Retention[2] != 0.5 {
+		t.Errorf("Jan retention[2] = %v, want 0.5", jan.Retention[2])
+	}
+
+	feb := byMonth["2026-02"]
+	if feb.Size != 1 {
+		t.Errorf("Feb cohort size = %d, want 1 (carol)", feb.Size)
+	}
+	if len(feb.Retention) != 2 || feb.Retention[0] != 1.0 || feb.Retention[1] != 1.0 {
+		t.Errorf("Feb retention = %+v, want [1, 1]", feb.Retention)
+	}
+}
+
+func TestComputeCohorts_LookbackTrimsOldCohorts(t *testing.T) {
+	db := newTestDB(t)
+	old := time.Date(2023, 1, 5, 0, 0, 0, 0, time.UTC)
+	recent := time.Date(2026, 4, 5, 0, 0, 0, 0, time.UTC)
+
+	seedPR(t, db, "old-0", "veteran", old)
+	seedPR(t, db, "old-1", "veteran", recent) // still active recently
+	seedPR(t, db, "new-0", "rookie", recent)
+
+	// 6-month lookback: 2023-01 must be dropped, 2026-04 must stay.
+	rows, _, err := computeCohorts(db, time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC), 6)
+	if err != nil {
+		t.Fatalf("computeCohorts: %v", err)
+	}
+	for _, r := range rows {
+		if r.Month == "2023-01" {
+			t.Errorf("veteran 2023-01 cohort should be trimmed by lookback=6, got %+v", r)
+		}
+	}
+	found := false
+	for _, r := range rows {
+		if r.Month == "2026-04" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("rookie 2026-04 cohort should be present, got rows = %+v", rows)
+	}
+}
+
+func TestHandleGetCohorts_RespectsCache(t *testing.T) {
+	db := newTestDB(t)
+	cache, _ := ristretto.NewCache(&ristretto.Config{NumCounters: 1000, MaxCost: 1 << 20, BufferItems: 64})
+
+	seedPR(t, db, "p-0", "alice", time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC))
+
+	h := HandleGetCohorts(db, cache)
+
+	rec1 := httptest.NewRecorder()
+	h.ServeHTTP(rec1, httptest.NewRequest(http.MethodGet, "/contributors/cohorts", nil))
+	if rec1.Code != http.StatusOK {
+		t.Fatalf("first status = %d, body = %s", rec1.Code, rec1.Body.String())
+	}
+	cache.Wait()
+
+	// Mutate DB; second call should hit cache → identical body.
+	seedPR(t, db, "p-1", "bob", time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC))
+
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, httptest.NewRequest(http.MethodGet, "/contributors/cohorts", nil))
+	if rec1.Body.String() != rec2.Body.String() {
+		t.Errorf("cache miss\n1: %s\n2: %s", rec1.Body, rec2.Body)
+	}
+
+	// Verify the response shape is what frontend will expect.
+	var body cohortsResponse
+	if err := json.Unmarshal(rec1.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body.SchemaVersion != cohortsSchemaVer {
+		t.Errorf("schemaVersion = %d, want %d", body.SchemaVersion, cohortsSchemaVer)
+	}
+}

--- a/server/handler/teams/collab.go
+++ b/server/handler/teams/collab.go
@@ -1,0 +1,187 @@
+package teams
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/dgraph-io/ristretto"
+	"github.com/samouraiworld/topofgnomes/server/teams"
+	"gorm.io/gorm"
+)
+
+const (
+	collabCacheTTL  = 5 * time.Minute
+	collabSchemaVer = 1
+	// Hide noise contributors that pollute the matrix (review bots).
+	// Case-insensitive match on the GitHub login.
+	collabBotLogin = "dependabot"
+)
+
+// collabRow is one (author_team, reviewer_team, count) cell.
+type collabRow struct {
+	AuthorTeam   string `json:"authorTeam"`
+	ReviewerTeam string `json:"reviewerTeam"`
+	Reviews      int    `json:"reviews"`
+}
+
+type collabResponse struct {
+	SchemaVersion int        `json:"schemaVersion"`
+	LastSyncedAt  *time.Time `json:"lastSyncedAt"`
+	Period        string     `json:"period"`
+	// Stable team-slug list in the order the matrix axes should be drawn.
+	// Matches the roster from teams.yaml (lowercase slugs).
+	Teams []string `json:"teams"`
+	// Sparse list of non-zero cells. Frontend builds the 2D matrix.
+	// Order: by AuthorTeam asc, ReviewerTeam asc.
+	Cells []collabRow `json:"cells"`
+	// Outsider review counts — reviews where author or reviewer doesn't
+	// belong to any team in the roster. Useful for honesty in the
+	// "what we're missing" footer of the chart.
+	OutsiderReviewsByAuthorTeam   map[string]int `json:"outsiderReviewsByAuthorTeam,omitempty"`
+	OutsiderReviewsByReviewerTeam map[string]int `json:"outsiderReviewsByReviewerTeam,omitempty"`
+}
+
+// HandleGetTeamCollab returns the cross-team review matrix. Each cell is
+// the number of MERGED-PR reviews where a member of team `authorTeam`
+// authored the PR and a member of team `reviewerTeam` reviewed it.
+//
+// Dependabot is excluded from both sides; self-reviews (same user as
+// author) are excluded too.
+//
+// `?time=` accepts `daily|weekly|monthly|yearly|""`(all-time).
+// Cached 5 min via ristretto keyed on the period.
+func HandleGetTeamCollab(db *gorm.DB, cfg *teams.Config, cache *ristretto.Cache) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		period := r.URL.Query().Get("time")
+		key := fmt.Sprintf("team-collab:%s", period)
+		if cache != nil {
+			if cached, ok := cache.Get(key); ok {
+				_ = json.NewEncoder(w).Encode(cached.(collabResponse))
+				return
+			}
+		}
+
+		resp, err := computeTeamCollab(db, cfg, period)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if cache != nil {
+			cache.SetWithTTL(key, resp, 0, collabCacheTTL)
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}
+}
+
+// computeTeamCollab runs the query + aggregation. Factored out for tests.
+func computeTeamCollab(db *gorm.DB, cfg *teams.Config, period string) (collabResponse, error) {
+	if db == nil {
+		return collabResponse{}, fmt.Errorf("db is nil")
+	}
+	if cfg == nil {
+		return collabResponse{}, fmt.Errorf("teams config is nil")
+	}
+
+	startTime := periodStart(period)
+
+	type row struct {
+		AuthorLogin   string `gorm:"column:author_login"`
+		ReviewerLogin string `gorm:"column:reviewer_login"`
+		Reviews       int    `gorm:"column:reviews"`
+	}
+
+	// Join reviews → pull_requests (to get PR author) → users for both sides.
+	// Exclude self-reviews and the dependabot bot account.
+	q := db.Table("reviews").
+		Select(`author_users.login AS author_login,
+		        reviewer_users.login AS reviewer_login,
+		        COUNT(*) AS reviews`).
+		Joins("JOIN pull_requests ON pull_requests.id = reviews.pull_request_id").
+		Joins("JOIN users AS author_users ON author_users.id = pull_requests.author_id").
+		Joins("JOIN users AS reviewer_users ON reviewer_users.id = reviews.author_id").
+		Where("pull_requests.state = ?", "MERGED").
+		Where("author_users.id <> reviewer_users.id").
+		Where("LOWER(author_users.login) <> ?", collabBotLogin).
+		Where("LOWER(reviewer_users.login) <> ?", collabBotLogin).
+		Group("author_users.login, reviewer_users.login")
+	if !startTime.IsZero() {
+		q = q.Where("reviews.created_at >= ?", startTime)
+	}
+
+	var rows []row
+	if err := q.Scan(&rows).Error; err != nil {
+		return collabResponse{}, fmt.Errorf("team-collab query: %w", err)
+	}
+
+	// Build a case-insensitive login→team lookup once.
+	loginToTeam := map[string]string{} // lowercased login -> slug
+	teamSlugs := make([]string, 0, len(cfg.Teams))
+	for _, t := range cfg.Teams {
+		teamSlugs = append(teamSlugs, t.Slug)
+		for _, m := range t.Members {
+			loginToTeam[strings.ToLower(m)] = t.Slug
+		}
+	}
+	sort.Strings(teamSlugs)
+
+	// Aggregate into the matrix. `cells` is sparse — frontend densifies.
+	type pairKey struct{ a, r string }
+	matrix := map[pairKey]int{}
+	outsiderByAuthor := map[string]int{}
+	outsiderByReviewer := map[string]int{}
+	for _, rr := range rows {
+		aTeam, aOk := loginToTeam[strings.ToLower(rr.AuthorLogin)]
+		rTeam, rOk := loginToTeam[strings.ToLower(rr.ReviewerLogin)]
+		switch {
+		case aOk && rOk:
+			matrix[pairKey{a: aTeam, r: rTeam}] += rr.Reviews
+		case aOk && !rOk:
+			outsiderByAuthor[aTeam] += rr.Reviews
+		case !aOk && rOk:
+			outsiderByReviewer[rTeam] += rr.Reviews
+		}
+		// reviews where neither side is in any team — drop entirely.
+	}
+
+	cells := make([]collabRow, 0, len(matrix))
+	for k, v := range matrix {
+		cells = append(cells, collabRow{
+			AuthorTeam:   k.a,
+			ReviewerTeam: k.r,
+			Reviews:      v,
+		})
+	}
+	sort.Slice(cells, func(i, j int) bool {
+		if cells[i].AuthorTeam != cells[j].AuthorTeam {
+			return cells[i].AuthorTeam < cells[j].AuthorTeam
+		}
+		return cells[i].ReviewerTeam < cells[j].ReviewerTeam
+	})
+
+	// LastSyncedAt mirrors the convention from stats.go / team-stats.
+	var lastSyncedAt *time.Time
+	var status struct {
+		ID           int       `gorm:"column:id;primaryKey"`
+		LastSyncedAt time.Time `gorm:"column:last_synced_at"`
+	}
+	if err := db.Table("sync_statuses").First(&status, 1).Error; err == nil && !status.LastSyncedAt.IsZero() {
+		ts := status.LastSyncedAt.UTC()
+		lastSyncedAt = &ts
+	}
+
+	resp := collabResponse{
+		SchemaVersion:                 collabSchemaVer,
+		LastSyncedAt:                  lastSyncedAt,
+		Period:                        period,
+		Teams:                         teamSlugs,
+		Cells:                         cells,
+		OutsiderReviewsByAuthorTeam:   outsiderByAuthor,
+		OutsiderReviewsByReviewerTeam: outsiderByReviewer,
+	}
+	return resp, nil
+}

--- a/server/handler/teams/collab_test.go
+++ b/server/handler/teams/collab_test.go
@@ -1,0 +1,194 @@
+package teams
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/dgraph-io/ristretto"
+	"github.com/samouraiworld/topofgnomes/server/models"
+	"gorm.io/gorm"
+)
+
+// seedReview attaches a Review row to an existing PR (created via seedMergedPR).
+// Returns the review ID so callers can assert if needed.
+func seedReview(t *testing.T, db *gorm.DB, prID, reviewerUserID, repoID string, createdAt time.Time) string {
+	t.Helper()
+	id := fmt.Sprintf("rv-%s-%s-%d", prID, reviewerUserID, createdAt.UnixNano())
+	rv := models.Review{
+		ID:            id,
+		PullRequestID: prID,
+		AuthorID:      reviewerUserID,
+		RepositoryID:  repoID,
+		CreatedAt:     createdAt,
+	}
+	if err := db.Create(&rv).Error; err != nil {
+		t.Fatalf("seed review: %v", err)
+	}
+	return id
+}
+
+// seedMergedPRReturnID is like seedMergedPR but returns the PR ID so a
+// review can target it. seedMergedPR uses a private prSeq counter so we
+// can rebuild the same id by predicting the next value.
+func seedMergedPRReturnID(t *testing.T, db *gorm.DB, repoID, authorID string, mergedAt time.Time) string {
+	t.Helper()
+	prSeq++
+	id := fmt.Sprintf("pr-%d", prSeq)
+	pr := models.PullRequest{
+		ID:           id,
+		RepositoryID: repoID,
+		State:        "MERGED",
+		AuthorID:     authorID,
+		MergedAt:     &mergedAt,
+		CreatedAt:    mergedAt.Add(-24 * time.Hour),
+	}
+	if err := db.Create(&pr).Error; err != nil {
+		t.Fatalf("seed pr: %v", err)
+	}
+	return id
+}
+
+func TestComputeTeamCollab_Basics(t *testing.T) {
+	db := newTestDB(t)
+	if err := db.AutoMigrate(&models.Review{}); err != nil {
+		t.Fatalf("migrate Review: %v", err)
+	}
+	cfg := fixtureConfig()
+
+	notJoon := seedUser(t, db, "notJoon")        // onbloc
+	r3v4s := seedUser(t, db, "r3v4s")            // onbloc
+	zxxma := seedUser(t, db, "zxxma")            // samouraiworld
+	n0izn0iz := seedUser(t, db, "n0izn0iz")      // samouraiworld
+	outsider := seedUser(t, db, "outsider")      // no team
+
+	mergedAt := time.Now().UTC().Add(-time.Hour)
+
+	// Onbloc author, samouraiworld reviewer (the canonical "collab" cell).
+	prA := seedMergedPRReturnID(t, db, "gnolang/gno", notJoon, mergedAt)
+	seedReview(t, db, prA, zxxma, "gnolang/gno", mergedAt)
+	seedReview(t, db, prA, n0izn0iz, "gnolang/gno", mergedAt)
+
+	// Onbloc author, onbloc reviewer (same-team cell).
+	prB := seedMergedPRReturnID(t, db, "onbloc/gnoscan", notJoon, mergedAt)
+	seedReview(t, db, prB, r3v4s, "onbloc/gnoscan", mergedAt)
+
+	// Outsider author with onbloc reviewer — outsider author bucket.
+	prC := seedMergedPRReturnID(t, db, "other/repo", outsider, mergedAt)
+	seedReview(t, db, prC, notJoon, "other/repo", mergedAt)
+
+	// Onbloc author, outsider reviewer — outsider reviewer bucket.
+	prD := seedMergedPRReturnID(t, db, "gnolang/gno", notJoon, mergedAt)
+	seedReview(t, db, prD, outsider, "gnolang/gno", mergedAt)
+
+	resp, err := computeTeamCollab(db, cfg, "")
+	if err != nil {
+		t.Fatalf("computeTeamCollab: %v", err)
+	}
+	if resp.SchemaVersion != collabSchemaVer {
+		t.Errorf("schemaVersion = %d, want %d", resp.SchemaVersion, collabSchemaVer)
+	}
+	cellMap := map[string]int{}
+	for _, c := range resp.Cells {
+		cellMap[c.AuthorTeam+":"+c.ReviewerTeam] = c.Reviews
+	}
+	if got := cellMap["onbloc:samouraiworld"]; got != 2 {
+		t.Errorf("onbloc → samouraiworld = %d, want 2", got)
+	}
+	if got := cellMap["onbloc:onbloc"]; got != 1 {
+		t.Errorf("onbloc → onbloc = %d, want 1 (intra-team r3v4s review of notJoon)", got)
+	}
+	if got := resp.OutsiderReviewsByReviewerTeam["onbloc"]; got != 1 {
+		t.Errorf("outsider→onbloc bucket = %d, want 1", got)
+	}
+	if got := resp.OutsiderReviewsByAuthorTeam["onbloc"]; got != 1 {
+		t.Errorf("onbloc→outsider bucket = %d, want 1", got)
+	}
+}
+
+func TestComputeTeamCollab_ExcludesDependabotAndSelfReviews(t *testing.T) {
+	db := newTestDB(t)
+	if err := db.AutoMigrate(&models.Review{}); err != nil {
+		t.Fatalf("migrate Review: %v", err)
+	}
+	cfg := fixtureConfig()
+
+	notJoon := seedUser(t, db, "notJoon")
+	dependabot := seedUser(t, db, "dependabot")
+	mergedAt := time.Now().UTC().Add(-time.Hour)
+
+	// Self-review: notJoon reviews their own PR. Must be filtered out.
+	prSelf := seedMergedPRReturnID(t, db, "gnolang/gno", notJoon, mergedAt)
+	seedReview(t, db, prSelf, notJoon, "gnolang/gno", mergedAt)
+
+	// Dependabot as author — bot row should be ignored entirely.
+	prBot := seedMergedPRReturnID(t, db, "gnolang/gno", dependabot, mergedAt)
+	seedReview(t, db, prBot, notJoon, "gnolang/gno", mergedAt)
+
+	// Dependabot as reviewer — also ignored.
+	prRev := seedMergedPRReturnID(t, db, "gnolang/gno", notJoon, mergedAt)
+	seedReview(t, db, prRev, dependabot, "gnolang/gno", mergedAt)
+
+	resp, err := computeTeamCollab(db, cfg, "")
+	if err != nil {
+		t.Fatalf("computeTeamCollab: %v", err)
+	}
+	if len(resp.Cells) != 0 {
+		t.Errorf("cells = %+v, want empty (everything filtered)", resp.Cells)
+	}
+	if len(resp.OutsiderReviewsByAuthorTeam) != 0 {
+		t.Errorf("outsider author bucket = %+v, want empty", resp.OutsiderReviewsByAuthorTeam)
+	}
+	if len(resp.OutsiderReviewsByReviewerTeam) != 0 {
+		t.Errorf("outsider reviewer bucket = %+v, want empty", resp.OutsiderReviewsByReviewerTeam)
+	}
+}
+
+func TestHandleGetTeamCollab_CachesResponse(t *testing.T) {
+	db := newTestDB(t)
+	if err := db.AutoMigrate(&models.Review{}); err != nil {
+		t.Fatalf("migrate Review: %v", err)
+	}
+	cfg := fixtureConfig()
+	cache, _ := ristretto.NewCache(&ristretto.Config{NumCounters: 1000, MaxCost: 1 << 20, BufferItems: 64})
+
+	notJoon := seedUser(t, db, "notJoon")
+	zxxma := seedUser(t, db, "zxxma")
+	mergedAt := time.Now().UTC().Add(-time.Hour)
+
+	pr := seedMergedPRReturnID(t, db, "gnolang/gno", notJoon, mergedAt)
+	seedReview(t, db, pr, zxxma, "gnolang/gno", mergedAt)
+
+	h := HandleGetTeamCollab(db, cfg, cache)
+
+	rec1 := httptest.NewRecorder()
+	h.ServeHTTP(rec1, httptest.NewRequest(http.MethodGet, "/team-collab", nil))
+	if rec1.Code != http.StatusOK {
+		t.Fatalf("first call status = %d", rec1.Code)
+	}
+	cache.Wait()
+
+	// Mutate underlying data: if the second call hits cache, the response stays identical.
+	pr2 := seedMergedPRReturnID(t, db, "gnolang/gno", notJoon, mergedAt)
+	seedReview(t, db, pr2, zxxma, "gnolang/gno", mergedAt)
+
+	rec2 := httptest.NewRecorder()
+	h.ServeHTTP(rec2, httptest.NewRequest(http.MethodGet, "/team-collab", nil))
+	if rec1.Body.String() != rec2.Body.String() {
+		t.Errorf("cache miss between calls\n1: %s\n2: %s", rec1.Body, rec2.Body)
+	}
+
+	// Different period key must NOT hit the prior cache entry.
+	rec3 := httptest.NewRecorder()
+	h.ServeHTTP(rec3, httptest.NewRequest(http.MethodGet, "/team-collab?time=monthly", nil))
+	var bodyMonthly collabResponse
+	if err := json.Unmarshal(rec3.Body.Bytes(), &bodyMonthly); err != nil {
+		t.Fatalf("unmarshal monthly: %v", err)
+	}
+	if bodyMonthly.Period != "monthly" {
+		t.Errorf("period = %q, want monthly", bodyMonthly.Period)
+	}
+}

--- a/server/main.go
+++ b/server/main.go
@@ -183,8 +183,10 @@ func main() {
 	router.Get("/teams/{slug}", teamshandler.HandleGetBySlug(teamsCfg))
 	router.Get("/teams/{slug}/active-repos", teamshandler.HandleGetActiveRepos(database, teamsCfg, cache))
 	router.Get("/teams/{slug}/team-stats", teamshandler.HandleGetTeamStats(database, teamsCfg, cache))
+	router.Get("/team-collab", teamshandler.HandleGetTeamCollab(database, teamsCfg, cache))
 
 	router.Get("/topics", topicshandler.HandleGetAll(topicsCfg))
+	router.Get("/contributors/cohorts", contributor.HandleGetCohorts(database, cache))
 
 	router.HandleFunc("/repositories", handler.HandleGetRepository(database))
 	router.HandleFunc("/stats", handler.HandleGetUserStats(database, cache))


### PR DESCRIPTION
## Summary

Two new aggregation endpoints so the Memba analytics rework can ship the two panels it couldn't reach with current data: contributor cohort retention and cross-team collaboration matrix. **Neither needs new ingestion** — the required data was already in the schema (`pull_requests.created_at` for cohorts, the `reviews` table for collab).

Paired with samouraiworld/memba#344 (in flight). The Memba follow-up that consumes these endpoints will land after this one deploys.

## Endpoints

### `GET /contributors/cohorts`
- Per-author `MIN(created_at)` over the PR table picks each user's cohort month.
- For each cohort: size + retention curve where `retention[N]` = fraction of the cohort that had ≥1 PR in the Nth month after cohort (index 0 always 1.0).
- 24-month lookback so the chart stays legible.
- 5-min ristretto cache (no query params).

### `GET /team-collab`
- Per-(`authorTeam`, `reviewerTeam`) review count over MERGED PRs.
- Joins `reviews` → `pull_requests` → `users` twice (author and reviewer), maps each login to its team via `teams.yaml`.
- **Self-reviews excluded** (`author.id != reviewer.id`).
- **Dependabot excluded** (case-insensitive login match) — would otherwise pollute Core Team's row/column with noise.
- Reviews where exactly one side has no team go into `outsiderReviewsByAuthorTeam` / `outsiderReviewsByReviewerTeam` so the frontend can be honest about coverage.
- `?time=daily|weekly|monthly|yearly|""` filter on `reviews.created_at`. Cached 5-min per period key.

Both envelopes follow the established `{schemaVersion, lastSyncedAt, ...}` shape.

## Test plan

- [x] `go test ./...` green — new tests cover the cohort math, the dependabot/self-review exclusions, the outsider buckets, the cache-hit behavior, and the response shape.
- [x] `go build ./...` clean.
- [ ] After merge + deploy: `curl https://backend.gnolove.world/contributors/cohorts | jq '.cohorts | length'` returns N>0.
- [ ] `curl https://backend.gnolove.world/team-collab | jq '.cells | length'` returns N>0; check `dependabot` doesn't appear in cells; outsider buckets present when there are reviews from non-team contributors.

## Risk

Two read-only aggregation endpoints. No new tables, no new columns, no migrations. Schema is identical pre/post-deploy. Both routes added next to the existing `/teams/*` + `/topics` block in `main.go`.

## Notes for the deploy

Same workflow_dispatch flow as #222:

```bash
gh workflow run "Docker build and deploy Image V2" -R samouraiworld/gnolove --ref main
```

~2 minutes; image rebuild + SSH + `docker compose pull && up -d`. No env var changes.