### PR TITLE
chore: update Samouraiworld description, add gno-ibc, sync topics

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -6,7 +6,7 @@ GNO_RPC_ENDPOINT=https://rpc.test8.gno.land:443
 GITHUB_OAUTH_CLIENT_ID=
 GITHUB_OAUTH_CLIENT_SECRET=
 GITHUB_API_TOKEN=
-GITHUB_REPOSITORIES=gnolang/gno/master onbloc/gnoscan/main onbloc/adena-wallet/main onbloc/adena-wallet-sdk/main gnolang/gnopls/master TERITORI/teritori-dapp/main gnolang/hackerspace/main gnolang/gnokey-mobile/main samouraiworld/zenao/main samouraiworld/gnolove/main samouraiworld/gnomonitoring/main samouraiworld/peerdev/main samouraiworld/memba/main
+GITHUB_REPOSITORIES=gnolang/gno/master onbloc/gnoscan/main onbloc/adena-wallet/main onbloc/adena-wallet-sdk/main onbloc/gno-ibc/main gnolang/gnopls/master TERITORI/teritori-dapp/main gnolang/hackerspace/main gnolang/gnokey-mobile/main samouraiworld/zenao/main samouraiworld/gnolove/main samouraiworld/gnomonitoring/main samouraiworld/peerdev/main samouraiworld/memba/main
 
 GHVERIFY_OWNER_MNEMONIC=
 GHVERIFY_REALM_PATH=

--- a/server/config/teams.yaml
+++ b/server/config/teams.yaml
@@ -75,7 +75,7 @@ teams:
   - slug: samouraiworld
     name: Samourai.world
     color: red
-    description: Building Memba, gnolove, gnomonitoring, and ecosystem dApps.
+    description: Core contributors for +4 years and building ecosystem tools, dev tools, dApps for engineers and general public.
     members:
       - n0izn0iz
       - omarsy

--- a/server/config/topics.yaml
+++ b/server/config/topics.yaml
@@ -22,18 +22,45 @@ topics:
   - slug: gnovm
     label: Gno VM
     patterns:
+      - '\(gnovm\)'
       - '\bvm\b'
       - 'interpreter'
       - '\bstack[- ]engine\b'
-      - 'gnoland/gno'
+      - 'gnomod'
+      - 'precompile'
+      - 'type-check'
+      - 'transpile'
+      - '\bast\b'
+      - '\bparser\b'
+
+  - slug: consensus
+    label: Consensus
+    patterns:
+      - '\(consensus\)'
+      - '\bconsensus\b'
+      - '\btendermint\b'
+      - '\bbft\b'
+      - '\bvalidator set\b'
+      - '\bblock\b'
 
   - slug: gnocore
-    label: Core protocol
+    label: Core / TM2
     patterns:
+      - '\(tm2\)'
       - '\bcore\b'
       - '\bprotocol\b'
       - 'tm2'
-      - 'consensus'
+
+  - slug: realms
+    label: Realms & packages
+    patterns:
+      - '\(gno\.land\)'
+      - '\brealm\b'
+      - '\bpackage\b'
+      - 'grc20'
+      - '\bavl\b'
+      - 'r/'
+      - 'p/'
 
   - slug: gnosdk
     label: SDK
@@ -45,11 +72,13 @@ topics:
   - slug: gnops
     label: Ops & infra
     patterns:
+      - '\(ci\)'
+      - '\(build\)'
       - 'portal[- ]loop'
-      - 'validator'
       - '\binfra\b'
       - 'deploy'
       - '\bops\b'
+      - '\bci\b'
 
   - slug: security
     label: Security
@@ -70,6 +99,26 @@ topics:
       - '\btooling\b'
       - '\blinter\b'
       - '\blsp\b'
+
+  - slug: frontend
+    label: Frontend
+    patterns:
+      - '\breact\b'
+      - '\bvite\b'
+      - '\bcss\b'
+      - '\bui\b'
+      - 'component'
+      - '\bux\b'
+      - '\bfrontend\b'
+
+  - slug: testing
+    label: Testing & CI
+    patterns:
+      - '\btest\b'
+      - '\bvitest\b'
+      - '\be2e\b'
+      - 'coverage'
+      - '\bci/cd\b'
 
   - slug: docs
     label: Docs
@@ -98,7 +147,6 @@ topics:
       - 'govdao'
       - '\bgovern'
       - '\bproposal'
-      - 'multisig'
 
   - slug: dex
     label: DEX


### PR DESCRIPTION
## Summary

- Updated Samouraiworld team description to "Core contributors for +4 years and building ecosystem tools, dev tools, dApps for engineers and general public."
- Added `onbloc/gno-ibc/main` to `GITHUB_REPOSITORIES` in `.env.example`
- Synced `topics.yaml` with Memba frontend classifier: 4 new topics (consensus, realms, frontend, testing), conventional-commit prefix patterns, refined gnovm patterns

## Action required after merge

- **VPS `.env` update**: add `onbloc/gno-ibc/main` to `GITHUB_REPOSITORIES` on the production VPS
- **Redeploy**: trigger "Docker build and deploy Image V2" workflow

## Test plan

- [ ] `go test ./topics/...` passes
- [ ] Backend starts with updated topics.yaml
- [ ] gno-ibc repo appears in tracked repos after VPS env update + redeploy