### PR TITLE
Add gno-agent-workspace to tracked repos

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -6,7 +6,7 @@ GNO_RPC_ENDPOINT=https://rpc.test8.gno.land:443
 GITHUB_OAUTH_CLIENT_ID=
 GITHUB_OAUTH_CLIENT_SECRET=
 GITHUB_API_TOKEN=
-GITHUB_REPOSITORIES=gnolang/gno/master onbloc/gnoscan/main onbloc/adena-wallet/main onbloc/adena-wallet-sdk/main onbloc/gno-ibc/main gnolang/gnopls/master TERITORI/teritori-dapp/main gnolang/hackerspace/main gnolang/gnokey-mobile/main samouraiworld/zenao/main samouraiworld/gnolove/main samouraiworld/gnomonitoring/main samouraiworld/peerdev/main samouraiworld/memba/main
+GITHUB_REPOSITORIES=gnolang/gno/master onbloc/gnoscan/main onbloc/adena-wallet/main onbloc/adena-wallet-sdk/main onbloc/gno-ibc/main gnolang/gnopls/master TERITORI/teritori-dapp/main gnolang/hackerspace/main gnolang/gnokey-mobile/main samouraiworld/zenao/main samouraiworld/gnolove/main samouraiworld/gnomonitoring/main samouraiworld/peerdev/main samouraiworld/memba/main samouraiworld/gno-agent-workspace/main
 
 GHVERIFY_OWNER_MNEMONIC=
 GHVERIFY_REALM_PATH=


### PR DESCRIPTION
## Summary

- Add `samouraiworld/gno-agent-workspace/main` to `GITHUB_REPOSITORIES` in `.env.example`

After merge, also add to the VPS `.env` and redeploy:
```
gh workflow run "Docker build and deploy Image V2" -R samouraiworld/gnolove --ref main
```

## Test plan

- [x] `.env.example` updated — serves as documentation for new deployments
- [ ] VPS `.env` update (requires SSH or Lours)
- [ ] Backend redeploy to pick up new repo